### PR TITLE
Added support for more formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,6 @@ jobs:
         with:
           arch: x64
 
-      - name: Test download SQLite driver
-        shell: bash
-        run: |
-          curl -fSL -vvv https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-0.5.1/adbc_driver_sqlite-0.5.1-py3-none-win_amd64.whl -o adbc_driver_sqlite-0.5.1-py3-none-win_amd64.whl | true
-
       - name: Compile and Test
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
         with:
           arch: x64
 
+      - name: Test download SQLite driver
+        shell: bash
+        run: |
+          curl -fSL -vvv https://github.com/apache/arrow-adbc/releases/download/apache-arrow-adbc-0.5.1/adbc_driver_sqlite-0.5.1-py3-none-win_amd64.whl -o adbc_driver_sqlite-0.5.1-py3-none-win_amd64.whl | true
+
       - name: Compile and Test
         shell: bash
         run: |

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -441,9 +441,14 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
         } else {
             format_processed = false;
         }
-    } else if (format_len >= 4) {
+    } else if (format_len >= 3) {
         if (strncmp("+w:", format, 3) == 0) {
             children_term = get_arrow_array_list_children(env, schema, values, level);
+        } else if (format_len > 3 && strncmp("w:", format, 2) == 0) {
+            if (get_arrow_array_children_as_list(env, schema, values, level, children, error) == 1) {
+                return 1;
+            }
+            children_term = enif_make_list_from_array(env, children.data(), (unsigned)schema->n_children); 
         } else if (format_len > 4 && (strncmp("+ud:", format, 4) == 0 || strncmp("+us:", format, 4) == 0)) {
             children_term = get_arrow_array_union_children(env, schema, values, level);
         } else {

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -460,8 +460,9 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
 
     if (!format_processed) {
         char buf[256] = { '\0' };
-        snprintf(buf, 255, "not implemented for format: `%s`", schema->format);
-        children_term = erlang::nif::error(env, erlang::nif::make_binary(env, buf));
+        snprintf(buf, 255, "not yet implemented for format: `%s`", schema->format);
+        error = erlang::nif::error(env, erlang::nif::make_binary(env, buf));
+        return 1;
         // printf("not implemented for format: `%s`\r\n", schema->format);
         // printf("length: %lld\r\n", values->length);
         // printf("null_count: %lld\r\n", values->null_count);

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -84,10 +84,59 @@ defmodule Adbc.Connection.Test do
   end
 
   describe "get_objects" do
-    @tag skip: "fails with bad tag"
     test "get all objects from a connection", %{db: db} do
       conn = start_supervised!({Connection, database: db})
-      {:ok, :done} = Connection.get_objects(conn, 0)
+
+      {:ok,
+       %Adbc.Result{
+         num_rows: nil,
+         data: %{
+           "catalog_db_schemas" => [
+             {"db_schema_name", []},
+             {"db_schema_tables",
+              [
+                {"table_name", []},
+                {"table_type", []},
+                {"table_columns",
+                 [
+                   {"column_name", []},
+                   {"ordinal_position", []},
+                   {"remarks", []},
+                   {"xdbc_data_type", []},
+                   {"xdbc_type_name", []},
+                   {"xdbc_column_size", []},
+                   {"xdbc_decimal_digits", []},
+                   {"xdbc_num_prec_radix", []},
+                   {"xdbc_nullable", []},
+                   {"xdbc_column_def", []},
+                   {"xdbc_sql_data_type", []},
+                   {"xdbc_datetime_sub", []},
+                   {"xdbc_char_octet_length", []},
+                   {"xdbc_is_nullable", []},
+                   {"xdbc_scope_catalog", []},
+                   {"xdbc_scope_schema", []},
+                   {"xdbc_scope_table", []},
+                   {"xdbc_is_autoincrement", []},
+                   {"xdbc_is_generatedcolumn", []}
+                 ]},
+                {"table_constraints",
+                 [
+                   {"constraint_name", []},
+                   {"constraint_type", []},
+                   {"constraint_column_names", []},
+                   {"constraint_column_usage",
+                    [
+                      {"fk_catalog", []},
+                      {"fk_db_schema", []},
+                      {"fk_table", []},
+                      {"fk_column_name", []}
+                    ]}
+                 ]}
+              ]}
+           ],
+           "catalog_name" => []
+         }
+       }} = Connection.get_objects(conn, 0)
     end
   end
 

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -57,7 +57,7 @@ defmodule Adbc.Connection.Test do
              {"int64_value", []},
              {"int32_bitmask", []},
              {"string_list", [{"item", []}]},
-             {"int32_to_int32_list_map", [[{"key", []}, {"value", [{"item", []}]}]]}
+             {"int32_to_int32_list_map", %{}}
            ]
          }
        }} = Connection.get_info(conn)
@@ -77,7 +77,7 @@ defmodule Adbc.Connection.Test do
              {"int64_value", []},
              {"int32_bitmask", []},
              {"string_list", [{"item", []}]},
-             {"int32_to_int32_list_map", [[{"key", []}, {"value", [{"item", []}]}]]}
+             {"int32_to_int32_list_map", %{}}
            ]
          }
        }} = Connection.get_info(conn, [0])

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -41,16 +41,46 @@ defmodule Adbc.Connection.Test do
   end
 
   describe "get_info" do
-    @tag skip: "fails with bad tag"
     test "get all info from a connection", %{db: db} do
       conn = start_supervised!({Connection, database: db})
-      {:ok, :done} = Connection.get_info(conn)
+
+      {:ok,
+       %Adbc.Result{
+         num_rows: nil,
+         data: %{
+           "info_name" => [0, 1, 100, 101, 102],
+           "info_value" => [
+             {"string_value",
+              # ["SQLite", "3.39.2", "ADBC SQLite Driver", "(unknown)", "0.2.0-SNAPSHOT"]},
+              ["SQLite", _, "ADBC SQLite Driver", _, _]},
+             {"bool_value", []},
+             {"int64_value", []},
+             {"int32_bitmask", []},
+             {"string_list", [{"item", []}]},
+             {"int32_to_int32_list_map", [[{"key", []}, {"value", [{"item", []}]}]]}
+           ]
+         }
+       }} = Connection.get_info(conn)
     end
 
-    @tag skip: "fails with bad tag"
     test "get some info from a connection", %{db: db} do
       conn = start_supervised!({Connection, database: db})
-      {:ok, :done} = Connection.get_info(conn, [1])
+
+      {:ok,
+       %Adbc.Result{
+         num_rows: nil,
+         data: %{
+           "info_name" => [0],
+           "info_value" => [
+             {"string_value", ["SQLite"]},
+             {"bool_value", []},
+             {"int64_value", []},
+             {"int32_bitmask", []},
+             {"string_list", [{"item", []}]},
+             {"int32_to_int32_list_map", [[{"key", []}, {"value", [{"item", []}]}]]}
+           ]
+         }
+       }} = Connection.get_info(conn, [0])
     end
   end
 

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -49,16 +49,15 @@ defmodule Adbc.Connection.Test do
          num_rows: nil,
          data: %{
            "info_name" => [0, 1, 100, 101, 102],
-           "info_value" => [
-             {"string_value",
-              # ["SQLite", "3.39.2", "ADBC SQLite Driver", "(unknown)", "0.2.0-SNAPSHOT"]},
-              ["SQLite", _, "ADBC SQLite Driver", _, _]},
-             {"bool_value", []},
-             {"int64_value", []},
-             {"int32_bitmask", []},
-             {"string_list", [{"item", []}]},
-             {"int32_to_int32_list_map", %{}}
-           ]
+           "info_value" => %{
+             "bool_value" => [],
+             "int32_bitmask" => [],
+             "int32_to_int32_list_map" => %{},
+             "int64_value" => [],
+             "string_list" => [],
+             # ["SQLite", "3.39.2", "ADBC SQLite Driver", "(unknown)", "0.2.0-SNAPSHOT"]},
+             "string_value" => ["SQLite", _, "ADBC SQLite Driver", _, _]
+           }
          }
        }} = Connection.get_info(conn)
     end
@@ -71,14 +70,14 @@ defmodule Adbc.Connection.Test do
          num_rows: nil,
          data: %{
            "info_name" => [0],
-           "info_value" => [
-             {"string_value", ["SQLite"]},
-             {"bool_value", []},
-             {"int64_value", []},
-             {"int32_bitmask", []},
-             {"string_list", [{"item", []}]},
-             {"int32_to_int32_list_map", %{}}
-           ]
+           "info_value" => %{
+             "bool_value" => [],
+             "int32_bitmask" => [],
+             "int32_to_int32_list_map" => %{},
+             "int64_value" => [],
+             "string_list" => [],
+             "string_value" => ["SQLite"]
+           }
          }
        }} = Connection.get_info(conn, [0])
     end


### PR DESCRIPTION
This PR fixes #14. It adds support for the following formats ([ADBC reference](https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings))

| format | description |
|-------|------------|
| `+ud:I,J,...` | dense union with type ids I,J… |
| `+us:I,J,...` | sparse union with type ids I,J… |
| `m` | `map` |
| `+w:123` | fixed-sized list [123 items] |
| `+L` | large list |
| `Z` | large binary |
| `U` | large utf-8 string |
| `w:42` | fixed-width binary [42 bytes] |