### PR TITLE
Add <cstdint> header to nif_utils.hpp

### DIFF
--- a/c_src/nif_utils.hpp
+++ b/c_src/nif_utils.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstring>
 #include <vector>
+#include <cstdint>
 
 #if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
 #define OS_WIN


### PR DESCRIPTION
This change adds a new line to include this header in `nif_utils.hpp`.

It fixes compilation on my machine that is running with newer versions of GCC and CMake.

Details of my setup:

```
-- The C compiler identification is GNU 13.1.1
-- The CXX compiler identification is GNU 13.1.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CXX_LINKER_SUPPORTS_VERSION_SCRIPT
-- Performing Test CXX_LINKER_SUPPORTS_VERSION_SCRIPT - Success
-- ---------------------------------------------------------------------
-- ADBC version: 0.5.1
-- 
-- Build configuration summary:
--   CMake version: 3.26.4
--   Generator: Unix Makefiles
```

I'm running on Fedora Linux 38 (AMD 64 bits).