### PR TITLE
expose more APIs

### DIFF
--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -693,7 +693,7 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
             // only handle and return children if this is a struct
             is_struct = true;
 
-            if (schema->n_children == values->n_children) {
+            if (values->length > 0) {
                 if (count == -1) count = values->n_children;
                 if (get_arrow_array_children_as_list(env, schema, values, offset, count, level, children, error) == 1) {
                     return 1;

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -693,7 +693,7 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
             // only handle and return children if this is a struct
             is_struct = true;
 
-            if (values->length > 0) {
+            if (values->length > 0 || values->release != nullptr) {
                 if (count == -1) count = values->n_children;
                 if (get_arrow_array_children_as_list(env, schema, values, offset, count, level, children, error) == 1) {
                     return 1;

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -1530,6 +1530,86 @@ static ERL_NIF_TERM adbc_statement_set_option(ErlNifEnv *env, int argc, const ER
     return erlang::nif::ok(env);
 }
 
+static ERL_NIF_TERM adbc_statement_set_option_bytes(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using res_type = NifRes<struct AdbcStatement>;
+
+    ERL_NIF_TERM error{};
+    res_type * statement = res_type::get_resource(env, argv[0], error);
+    if (statement == nullptr) {
+        return error;
+    }
+
+    std::string key, value;
+    if (!erlang::nif::get(env, argv[1], key)) {
+        return enif_make_badarg(env);
+    }
+    if (!erlang::nif::get(env, argv[2], value)) {
+        return enif_make_badarg(env);
+    }
+
+    struct AdbcError adbc_error{};
+    AdbcStatusCode code = AdbcStatementSetOptionBytes(&statement->val, key.c_str(), (const uint8_t *)value.data(), value.length(), &adbc_error);
+    if (code != ADBC_STATUS_OK) {
+        return nif_error_from_adbc_error(env, &adbc_error);
+    }
+
+    return erlang::nif::ok(env);
+}
+
+static ERL_NIF_TERM adbc_statement_set_option_int(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using res_type = NifRes<struct AdbcStatement>;
+
+    ERL_NIF_TERM error{};
+    res_type * statement = res_type::get_resource(env, argv[0], error);
+    if (statement == nullptr) {
+        return error;
+    }
+
+    std::string key;
+    int64_t value;
+    if (!erlang::nif::get(env, argv[1], key)) {
+        return enif_make_badarg(env);
+    }
+    if (!erlang::nif::get(env, argv[2], &value)) {
+        return enif_make_badarg(env);
+    }
+
+    struct AdbcError adbc_error{};
+    AdbcStatusCode code = AdbcStatementSetOptionInt(&statement->val, key.c_str(), value, &adbc_error);
+    if (code != ADBC_STATUS_OK) {
+        return nif_error_from_adbc_error(env, &adbc_error);
+    }
+    
+    return erlang::nif::ok(env);
+}
+
+static ERL_NIF_TERM adbc_statement_set_option_double(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using res_type = NifRes<struct AdbcStatement>;
+
+    ERL_NIF_TERM error{};
+    res_type * statement = res_type::get_resource(env, argv[0], error);
+    if (statement == nullptr) {
+        return error;
+    }
+
+    std::string key;
+    double value;
+    if (!erlang::nif::get(env, argv[1], key)) {
+        return enif_make_badarg(env);
+    }
+    if (!erlang::nif::get(env, argv[2], &value)) {
+        return enif_make_badarg(env);
+    }
+
+    struct AdbcError adbc_error{};
+    AdbcStatusCode code = AdbcStatementSetOptionDouble(&statement->val, key.c_str(), value, &adbc_error);
+    if (code != ADBC_STATUS_OK) {
+        return nif_error_from_adbc_error(env, &adbc_error);
+    }
+
+    return erlang::nif::ok(env);
+}
+
 static ERL_NIF_TERM adbc_statement_execute_query(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     using res_type = NifRes<struct AdbcStatement>;
     using array_stream_type = NifRes<struct ArrowArrayStream>;
@@ -1828,6 +1908,9 @@ static ErlNifFunc nif_functions[] = {
 
     {"adbc_statement_new", 1, adbc_statement_new, 0},
     {"adbc_statement_set_option", 3, adbc_statement_set_option, 0},
+    {"adbc_statement_set_option_bytes", 3, adbc_statement_set_option_bytes, 0},
+    {"adbc_statement_set_option_int", 3, adbc_statement_set_option_int, 0},
+    {"adbc_statement_set_option_double", 3, adbc_statement_set_option_double, 0},
     {"adbc_statement_execute_query", 1, adbc_statement_execute_query, 0},
     {"adbc_statement_prepare", 1, adbc_statement_prepare, 0},
     {"adbc_statement_set_sql_query", 2, adbc_statement_set_sql_query, 0},

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -1026,239 +1026,159 @@ static ERL_NIF_TERM adbc_database_new(ErlNifEnv *env, int argc, const ERL_NIF_TE
     return erlang::nif::ok(env, ret);
 }
 
+template <typename T, typename GetString, typename GetBytes, typename GetInt, typename GetDouble>
+static ERL_NIF_TERM adbc_get_option(ErlNifEnv *env, const ERL_NIF_TERM argv[], GetString& get_string, GetBytes& get_bytes, GetInt& get_int, GetDouble& get_double) {
+    using res_type = NifRes<T>;
+
+    ERL_NIF_TERM error{};
+    res_type * resource = nullptr;
+    if ((resource = res_type::get_resource(env, argv[0], error)) == nullptr) {
+        return error;
+    }
+
+    std::string type, key;
+    if (!erlang::nif::get(env, argv[1], type)) {
+        return enif_make_badarg(env);
+    }
+    if (!erlang::nif::get(env, argv[2], key)) {
+        return enif_make_badarg(env);
+    }
+
+    struct AdbcError adbc_error{};
+    if (type == "string" || type == "binary") {
+        int is_string = type == "string";
+        uint8_t value[64] = {'\0'};
+        constexpr size_t value_buffer_size = sizeof(value) / sizeof(value[0]);
+        size_t value_len = value_buffer_size;
+        AdbcStatusCode code;
+        size_t elem_size = 0;
+        if (is_string) {
+            elem_size = sizeof(char);
+            code = get_string(&resource->val, key.c_str(), (char *)value, &value_len, &adbc_error);
+        } else {
+            elem_size = sizeof(uint8_t);
+            code = get_bytes(&resource->val, key.c_str(), value, &value_len, &adbc_error);
+        }
+        if (code != ADBC_STATUS_OK) {
+            return nif_error_from_adbc_error(env, &adbc_error);
+        }
+
+        if (value_len > value_buffer_size) {
+            uint8_t * out_value = (uint8_t *)enif_alloc(elem_size * (value_len + 1));
+            memset(out_value, 0, elem_size * (value_len + 1));
+            value_len += 1;
+            if (is_string) {
+                code = get_string(&resource->val, key.c_str(), (char *)out_value, &value_len, &adbc_error);
+            } else {
+                code = get_bytes(&resource->val, key.c_str(), out_value, &value_len, &adbc_error);
+            }
+            
+            if (code != ADBC_STATUS_OK) {
+                return nif_error_from_adbc_error(env, &adbc_error);
+            }
+
+            // minus 1 to remove the null terminator for strings
+            ERL_NIF_TERM ret;
+            ret = erlang::nif::make_binary(env, (const char *)out_value, value_len - (is_string ? 1 : 0));
+            enif_free(out_value);
+            return erlang::nif::ok(env, ret);
+        } else {
+            // minus 1 to remove the null terminator for strings
+            return erlang::nif::ok(env, erlang::nif::make_binary(env, (const char *)value, value_len - (is_string ? 1 : 0)));
+        }
+    } else if (type == "integer") {
+        int64_t value = 0;
+        AdbcStatusCode code = get_int(&resource->val, key.c_str(), &value, &adbc_error);
+        if (code != ADBC_STATUS_OK) {
+            return nif_error_from_adbc_error(env, &adbc_error);
+        }
+
+        return erlang::nif::ok(env, erlang::nif::make(env, value));
+    } else if (type == "float") {
+        double value = 0;
+        AdbcStatusCode code = get_double(&resource->val, key.c_str(), &value, &adbc_error);
+        if (code != ADBC_STATUS_OK) {
+            return nif_error_from_adbc_error(env, &adbc_error);
+        }
+
+        return erlang::nif::ok(env, erlang::nif::make(env, value));
+    } else {
+        return enif_make_badarg(env);
+    }
+}
+
+template <typename T, typename SetString, typename SetBytes, typename SetInt, typename SetDouble>
+static ERL_NIF_TERM adbc_set_option(ErlNifEnv *env, const ERL_NIF_TERM argv[], SetString& set_string, SetBytes &set_bytes, SetInt &set_int, SetDouble &set_double) {
+    using res_type = NifRes<T>;
+
+    ERL_NIF_TERM error{};
+    res_type * resource = nullptr;
+    if ((resource = res_type::get_resource(env, argv[0], error)) == nullptr) {
+        return error;
+    }
+
+    std::string type, key;
+    if (!erlang::nif::get_atom(env, argv[1], type)) {
+        return enif_make_badarg(env);
+    }
+    if (!erlang::nif::get(env, argv[2], key)) {
+        return enif_make_badarg(env);
+    }
+
+    struct AdbcError adbc_error{};
+    AdbcStatusCode code;
+    if (type == "string" || type == "binary") {
+        std::string value;
+        if (!erlang::nif::get(env, argv[3], value)) {
+            return enif_make_badarg(env);
+        }
+        if (type == "string") {
+            code = set_string(&resource->val, key.c_str(), value.c_str(), &adbc_error);
+        } else {
+            code = set_bytes(&resource->val, key.c_str(), (const uint8_t *)value.data(), value.length(), &adbc_error);
+        }
+    } else if (type == "integer") {
+        int64_t value;
+        if (!erlang::nif::get(env, argv[3], &value)) {
+            return enif_make_badarg(env);
+        }
+        code = set_int(&resource->val, key.c_str(), value, &adbc_error);
+    } else if (type == "float") {
+        double value;
+        if (!erlang::nif::get(env, argv[3], &value)) {
+            return enif_make_badarg(env);
+        }
+        code = set_double(&resource->val, key.c_str(), value, &adbc_error);
+    } else {
+        return enif_make_badarg(env);
+    }
+
+    if (code != ADBC_STATUS_OK) {
+        return nif_error_from_adbc_error(env, &adbc_error);
+    }
+    return erlang::nif::ok(env);
+}
+
 static ERL_NIF_TERM adbc_database_get_option(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcDatabase>;
-
-    ERL_NIF_TERM error{};
-    res_type * database = nullptr;
-    if ((database = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    char value[64] = {'\0'};
-    constexpr size_t value_buffer_size = sizeof(value) / sizeof(value[0]);
-    size_t value_len = value_buffer_size;
-    AdbcStatusCode code = AdbcDatabaseGetOption(&database->val, key.c_str(), value, &value_len, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-    if (value_len > value_buffer_size) {
-        char * out_value = (char *)enif_alloc(sizeof(char) * (value_len + 1));
-        memset(out_value, 0, sizeof(char) * (value_len + 1));
-        value_len += 1;
-        code = AdbcDatabaseGetOption(&database->val, key.c_str(), out_value, &value_len, &adbc_error);
-        if (code != ADBC_STATUS_OK) {
-            return nif_error_from_adbc_error(env, &adbc_error);
-        }
-        // minus 1 to remove the null terminator
-        ERL_NIF_TERM ret = erlang::nif::make_binary(env, out_value, value_len - 1);
-        enif_free(out_value);
-        return erlang::nif::ok(env, ret);
-    } else {
-        // minus 1 to remove the null terminator
-        return erlang::nif::ok(env, erlang::nif::make_binary(env, value, value_len - 1));
-    }
-}
-
-static ERL_NIF_TERM adbc_database_get_option_bytes(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcDatabase>;
-
-    ERL_NIF_TERM error{};
-    res_type * database = nullptr;
-    if ((database = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    uint8_t value[64] = {'\0'};
-    constexpr size_t value_buffer_size = sizeof(value) / sizeof(value[0]);
-    size_t value_len = value_buffer_size;
-    AdbcStatusCode code = AdbcDatabaseGetOptionBytes(&database->val, key.c_str(), value, &value_len, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-    if (value_len > value_buffer_size) {
-        uint8_t * out_value = (uint8_t *)enif_alloc(sizeof(uint8_t) * (value_len + 1));
-        if (!out_value) {
-            return erlang::nif::error(env, "out of memory");
-        }
-        memset(out_value, 0, sizeof(uint8_t) * (value_len + 1));
-        value_len += 1;
-        code = AdbcDatabaseGetOptionBytes(&database->val, key.c_str(), out_value, &value_len, &adbc_error);
-        if (code != ADBC_STATUS_OK) {
-            return nif_error_from_adbc_error(env, &adbc_error);
-        }
-        ERL_NIF_TERM ret = erlang::nif::make_binary(env, (const char *)out_value, value_len);
-        enif_free(out_value);
-        return erlang::nif::ok(env, ret);
-    } else {
-        return erlang::nif::ok(env, erlang::nif::make_binary(env, (const char *)value, value_len));
-    }
-}
-
-static ERL_NIF_TERM adbc_database_get_option_int(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcDatabase>;
-
-    ERL_NIF_TERM error{};
-    res_type * database = nullptr;
-    if ((database = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    int64_t value = 0;
-    AdbcStatusCode code = AdbcDatabaseGetOptionInt(&database->val, key.c_str(), &value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env, erlang::nif::make(env, value));
-}
-
-static ERL_NIF_TERM adbc_database_get_option_double(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcDatabase>;
-
-    ERL_NIF_TERM error{};
-    res_type * database = nullptr;
-    if ((database = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    double value = 0;
-    AdbcStatusCode code = AdbcDatabaseGetOptionDouble(&database->val, key.c_str(), &value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env, erlang::nif::make(env, value));
+    return adbc_get_option<struct AdbcDatabase>(
+        env,
+        argv,
+        AdbcDatabaseGetOption,
+        AdbcDatabaseGetOptionBytes,
+        AdbcDatabaseGetOptionInt,
+        AdbcDatabaseGetOptionDouble
+    );
 }
 
 static ERL_NIF_TERM adbc_database_set_option(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcDatabase>;
-
-    ERL_NIF_TERM error{};
-    res_type * database = nullptr;
-    if ((database = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key, value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcDatabaseSetOption(&database->val, key.c_str(), value.c_str(), &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_database_set_option_bytes(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcDatabase>;
-
-    ERL_NIF_TERM error{};
-    res_type * database = nullptr;
-    if ((database = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key, value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcDatabaseSetOptionBytes(&database->val, key.c_str(), (const uint8_t *)value.data(), value.length(), &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_database_set_option_int(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcDatabase>;
-
-    ERL_NIF_TERM error{};
-    res_type * database = nullptr;
-    if ((database = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    int64_t value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], &value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcDatabaseSetOptionInt(&database->val, key.c_str(), value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_database_set_option_double(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcDatabase>;
-
-    ERL_NIF_TERM error{};
-    res_type * database = nullptr;
-    if ((database = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    double value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], &value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcDatabaseSetOptionDouble(&database->val, key.c_str(), value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
+    return adbc_set_option<struct AdbcDatabase>(
+        env,
+        argv,
+        AdbcDatabaseSetOption,
+        AdbcDatabaseSetOptionBytes,
+        AdbcDatabaseSetOptionInt,
+        AdbcDatabaseSetOptionDouble
+    );
 }
 
 static ERL_NIF_TERM adbc_database_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -1299,238 +1219,25 @@ static ERL_NIF_TERM adbc_connection_new(ErlNifEnv *env, int argc, const ERL_NIF_
 }
 
 static ERL_NIF_TERM adbc_connection_get_option(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcConnection>;
-
-    ERL_NIF_TERM error{};
-    res_type * connection = res_type::get_resource(env, argv[0], error);
-    if (connection == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    char value[64] = {'\0'};
-    constexpr size_t value_buffer_size = sizeof(value) / sizeof(value[0]);
-    size_t value_len = value_buffer_size;
-    AdbcStatusCode code = AdbcConnectionGetOption(&connection->val, key.c_str(), value, &value_len, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-    if (value_len > value_buffer_size) {
-        char * out_value = (char *)enif_alloc(sizeof(char) * (value_len + 1));
-        memset(out_value, 0, sizeof(char) * (value_len + 1));
-        value_len += 1;
-        code = AdbcConnectionGetOption(&connection->val, key.c_str(), out_value, &value_len, &adbc_error);
-        if (code != ADBC_STATUS_OK) {
-            return nif_error_from_adbc_error(env, &adbc_error);
-        }
-        // minus 1 to remove the null terminator
-        ERL_NIF_TERM ret = erlang::nif::make_binary(env, out_value, value_len - 1);
-        enif_free(out_value);
-        return erlang::nif::ok(env, ret);
-    } else {
-        // minus 1 to remove the null terminator
-        return erlang::nif::ok(env, erlang::nif::make_binary(env, value, value_len - 1));
-    }
-}
-
-static ERL_NIF_TERM adbc_connection_get_option_bytes(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcConnection>;
-
-    ERL_NIF_TERM error{};
-    res_type * connection = nullptr;
-    if ((connection = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    uint8_t value[64] = {'\0'};
-    constexpr size_t value_buffer_size = sizeof(value) / sizeof(value[0]);
-    size_t value_len = value_buffer_size;
-    AdbcStatusCode code = AdbcConnectionGetOptionBytes(&connection->val, key.c_str(), value, &value_len, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-    if (value_len > value_buffer_size) {
-        uint8_t * out_value = (uint8_t *)enif_alloc(sizeof(uint8_t) * (value_len + 1));
-        if (!out_value) {
-            return erlang::nif::error(env, "out of memory");
-        }
-        memset(out_value, 0, sizeof(uint8_t) * (value_len + 1));
-        value_len += 1;
-        code = AdbcConnectionGetOptionBytes(&connection->val, key.c_str(), out_value, &value_len, &adbc_error);
-        if (code != ADBC_STATUS_OK) {
-            return nif_error_from_adbc_error(env, &adbc_error);
-        }
-        ERL_NIF_TERM ret = erlang::nif::make_binary(env, (const char *)out_value, value_len);
-        enif_free(out_value);
-        return erlang::nif::ok(env, ret);
-    } else {
-        return erlang::nif::ok(env, erlang::nif::make_binary(env, (const char *)value, value_len));
-    }
-}
-
-static ERL_NIF_TERM adbc_connection_get_option_int(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcConnection>;
-
-    ERL_NIF_TERM error{};
-    res_type * connection = nullptr;
-    if ((connection = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    int64_t value = 0;
-    AdbcStatusCode code = AdbcConnectionGetOptionInt(&connection->val, key.c_str(), &value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env, erlang::nif::make(env, value));
-}
-
-static ERL_NIF_TERM adbc_connection_get_option_double(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcConnection>;
-
-    ERL_NIF_TERM error{};
-    res_type * connection = nullptr;
-    if ((connection = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    double value = 0;
-    AdbcStatusCode code = AdbcConnectionGetOptionDouble(&connection->val, key.c_str(), &value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env, erlang::nif::make(env, value));
+    return adbc_get_option<struct AdbcConnection>(
+        env,
+        argv,
+        AdbcConnectionGetOption,
+        AdbcConnectionGetOptionBytes,
+        AdbcConnectionGetOptionInt,
+        AdbcConnectionGetOptionDouble
+    );
 }
 
 static ERL_NIF_TERM adbc_connection_set_option(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcConnection>;
-
-    ERL_NIF_TERM error{};
-    res_type * connection = res_type::get_resource(env, argv[0], error);
-    if (connection == nullptr) {
-        return error;
-    }
-
-    std::string key, value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcConnectionSetOption(&connection->val, key.c_str(), value.c_str(), &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_connection_set_option_bytes(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcConnection>;
-
-    ERL_NIF_TERM error{};
-    res_type * connection = res_type::get_resource(env, argv[0], error);
-    if (connection == nullptr) {
-        return error;
-    }
-
-    std::string key, value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcConnectionSetOptionBytes(&connection->val, key.c_str(), (const uint8_t *)value.data(), value.length(), &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_connection_set_option_int(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcConnection>;
-
-    ERL_NIF_TERM error{};
-    res_type * connection = res_type::get_resource(env, argv[0], error);
-    if (connection == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    int64_t value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], &value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcConnectionSetOptionInt(&connection->val, key.c_str(), value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_connection_set_option_double(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcConnection>;
-
-    ERL_NIF_TERM error{};
-    res_type * connection = res_type::get_resource(env, argv[0], error);
-    if (connection == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    double value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], &value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcConnectionSetOptionDouble(&connection->val, key.c_str(), value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
+    return adbc_set_option<struct AdbcConnection>(
+        env,
+        argv,
+        AdbcConnectionSetOption,
+        AdbcConnectionSetOptionBytes,
+        AdbcConnectionSetOptionInt,
+        AdbcConnectionSetOptionDouble
+    );
 }
 
 static ERL_NIF_TERM adbc_connection_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -1847,238 +1554,25 @@ static ERL_NIF_TERM adbc_statement_new(ErlNifEnv *env, int argc, const ERL_NIF_T
 }
 
 static ERL_NIF_TERM adbc_statement_get_option(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcStatement>;
-
-    ERL_NIF_TERM error{};
-    res_type * statement = res_type::get_resource(env, argv[0], error);
-    if (statement == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    char value[64] = {'\0'};
-    constexpr size_t value_buffer_size = sizeof(value) / sizeof(value[0]);
-    size_t value_len = value_buffer_size;
-    AdbcStatusCode code = AdbcStatementGetOption(&statement->val, key.c_str(), value, &value_len, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-    if (value_len > value_buffer_size) {
-        char * out_value = (char *)enif_alloc(sizeof(char) * (value_len + 1));
-        memset(out_value, 0, sizeof(char) * (value_len + 1));
-        value_len += 1;
-        code = AdbcStatementGetOption(&statement->val, key.c_str(), out_value, &value_len, &adbc_error);
-        if (code != ADBC_STATUS_OK) {
-            return nif_error_from_adbc_error(env, &adbc_error);
-        }
-        // minus 1 to remove the null terminator
-        ERL_NIF_TERM ret = erlang::nif::make_binary(env, out_value, value_len - 1);
-        enif_free(out_value);
-        return erlang::nif::ok(env, ret);
-    } else {
-        // minus 1 to remove the null terminator
-        return erlang::nif::ok(env, erlang::nif::make_binary(env, value, value_len - 1));
-    }
-}
-
-static ERL_NIF_TERM adbc_statement_get_option_bytes(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcStatement>;
-
-    ERL_NIF_TERM error{};
-    res_type * statement = nullptr;
-    if ((statement = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    uint8_t value[64] = {'\0'};
-    constexpr size_t value_buffer_size = sizeof(value) / sizeof(value[0]);
-    size_t value_len = value_buffer_size;
-    AdbcStatusCode code = AdbcStatementGetOptionBytes(&statement->val, key.c_str(), value, &value_len, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-    if (value_len > value_buffer_size) {
-        uint8_t * out_value = (uint8_t *)enif_alloc(sizeof(uint8_t) * (value_len + 1));
-        if (!out_value) {
-            return erlang::nif::error(env, "out of memory");
-        }
-        memset(out_value, 0, sizeof(uint8_t) * (value_len + 1));
-        value_len += 1;
-        code = AdbcStatementGetOptionBytes(&statement->val, key.c_str(), out_value, &value_len, &adbc_error);
-        if (code != ADBC_STATUS_OK) {
-            return nif_error_from_adbc_error(env, &adbc_error);
-        }
-        ERL_NIF_TERM ret = erlang::nif::make_binary(env, (const char *)out_value, value_len);
-        enif_free(out_value);
-        return erlang::nif::ok(env, ret);
-    } else {
-        return erlang::nif::ok(env, erlang::nif::make_binary(env, (const char *)value, value_len));
-    }
-}
-
-static ERL_NIF_TERM adbc_statement_get_option_int(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcStatement>;
-
-    ERL_NIF_TERM error{};
-    res_type * statement = nullptr;
-    if ((statement = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    int64_t value = 0;
-    AdbcStatusCode code = AdbcStatementGetOptionInt(&statement->val, key.c_str(), &value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env, erlang::nif::make(env, value));
-}
-
-static ERL_NIF_TERM adbc_statement_get_option_double(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcStatement>;
-
-    ERL_NIF_TERM error{};
-    res_type * statement = nullptr;
-    if ((statement = res_type::get_resource(env, argv[0], error)) == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    double value = 0;
-    AdbcStatusCode code = AdbcStatementGetOptionDouble(&statement->val, key.c_str(), &value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env, erlang::nif::make(env, value));
+    return adbc_get_option<struct AdbcStatement>(
+        env,
+        argv,
+        AdbcStatementGetOption,
+        AdbcStatementGetOptionBytes,
+        AdbcStatementGetOptionInt,
+        AdbcStatementGetOptionDouble
+    );
 }
 
 static ERL_NIF_TERM adbc_statement_set_option(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcStatement>;
-
-    ERL_NIF_TERM error{};
-    res_type * statement = res_type::get_resource(env, argv[0], error);
-    if (statement == nullptr) {
-        return error;
-    }
-
-    std::string key, value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcStatementSetOption(&statement->val, key.c_str(), value.c_str(), &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_statement_set_option_bytes(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcStatement>;
-
-    ERL_NIF_TERM error{};
-    res_type * statement = res_type::get_resource(env, argv[0], error);
-    if (statement == nullptr) {
-        return error;
-    }
-
-    std::string key, value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcStatementSetOptionBytes(&statement->val, key.c_str(), (const uint8_t *)value.data(), value.length(), &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_statement_set_option_int(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcStatement>;
-
-    ERL_NIF_TERM error{};
-    res_type * statement = res_type::get_resource(env, argv[0], error);
-    if (statement == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    int64_t value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], &value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcStatementSetOptionInt(&statement->val, key.c_str(), value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-    
-    return erlang::nif::ok(env);
-}
-
-static ERL_NIF_TERM adbc_statement_set_option_double(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    using res_type = NifRes<struct AdbcStatement>;
-
-    ERL_NIF_TERM error{};
-    res_type * statement = res_type::get_resource(env, argv[0], error);
-    if (statement == nullptr) {
-        return error;
-    }
-
-    std::string key;
-    double value;
-    if (!erlang::nif::get(env, argv[1], key)) {
-        return enif_make_badarg(env);
-    }
-    if (!erlang::nif::get(env, argv[2], &value)) {
-        return enif_make_badarg(env);
-    }
-
-    struct AdbcError adbc_error{};
-    AdbcStatusCode code = AdbcStatementSetOptionDouble(&statement->val, key.c_str(), value, &adbc_error);
-    if (code != ADBC_STATUS_OK) {
-        return nif_error_from_adbc_error(env, &adbc_error);
-    }
-
-    return erlang::nif::ok(env);
+    return adbc_set_option<struct AdbcStatement>(
+        env,
+        argv,
+        AdbcStatementSetOption,
+        AdbcStatementSetOptionBytes,
+        AdbcStatementSetOptionInt,
+        AdbcStatementSetOptionDouble
+    );
 }
 
 static ERL_NIF_TERM adbc_statement_execute_query(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -2365,39 +1859,21 @@ static int on_upgrade(ErlNifEnv *, void **, void **, ERL_NIF_TERM) {
 
 static ErlNifFunc nif_functions[] = {
     {"adbc_database_new", 0, adbc_database_new, 0},
-    {"adbc_database_get_option", 2, adbc_database_get_option, 0},
-    {"adbc_database_get_option_bytes", 2, adbc_database_get_option_bytes, 0},
-    {"adbc_database_get_option_int", 2, adbc_database_get_option_int, 0},
-    {"adbc_database_get_option_double", 2, adbc_database_get_option_double, 0},
-    {"adbc_database_set_option", 3, adbc_database_set_option, 0},
-    {"adbc_database_set_option_bytes", 3, adbc_database_set_option_bytes, 0},
-    {"adbc_database_set_option_int", 3, adbc_database_set_option_int, 0},
-    {"adbc_database_set_option_double", 3, adbc_database_set_option_double, 0},
+    {"adbc_database_get_option", 3, adbc_database_get_option, 0},
+    {"adbc_database_set_option", 4, adbc_database_set_option, 0},
     {"adbc_database_init", 1, adbc_database_init, 0},
 
     {"adbc_connection_new", 0, adbc_connection_new, 0},
-    {"adbc_connection_get_option", 2, adbc_connection_get_option, 0},
-    {"adbc_connection_get_option_bytes", 2, adbc_connection_get_option_bytes, 0},
-    {"adbc_connection_get_option_int", 2, adbc_connection_get_option_int, 0},
-    {"adbc_connection_get_option_double", 2, adbc_connection_get_option_double, 0},
-    {"adbc_connection_set_option", 3, adbc_connection_set_option, 0},
-    {"adbc_connection_set_option_bytes", 3, adbc_connection_set_option_bytes, 0},
-    {"adbc_connection_set_option_int", 3, adbc_connection_set_option_int, 0},
-    {"adbc_connection_set_option_double", 3, adbc_connection_set_option_double, 0},
+    {"adbc_connection_get_option", 3, adbc_connection_get_option, 0},
+    {"adbc_connection_set_option", 4, adbc_connection_set_option, 0},
     {"adbc_connection_init", 2, adbc_connection_init, 0},
     {"adbc_connection_get_info", 2, adbc_connection_get_info, 0},
     {"adbc_connection_get_objects", 7, adbc_connection_get_objects, 0},
     {"adbc_connection_get_table_types", 1, adbc_connection_get_table_types, 0},
 
     {"adbc_statement_new", 1, adbc_statement_new, 0},
-    {"adbc_statement_get_option", 2, adbc_statement_get_option, 0},
-    {"adbc_statement_get_option_bytes", 2, adbc_statement_get_option_bytes, 0},
-    {"adbc_statement_get_option_int", 2, adbc_statement_get_option_int, 0},
-    {"adbc_statement_get_option_double", 2, adbc_statement_get_option_double, 0},
-    {"adbc_statement_set_option", 3, adbc_statement_set_option, 0},
-    {"adbc_statement_set_option_bytes", 3, adbc_statement_set_option_bytes, 0},
-    {"adbc_statement_set_option_int", 3, adbc_statement_set_option_int, 0},
-    {"adbc_statement_set_option_double", 3, adbc_statement_set_option_double, 0},
+    {"adbc_statement_get_option", 3, adbc_statement_get_option, 0},
+    {"adbc_statement_set_option", 4, adbc_statement_set_option, 0},
     {"adbc_statement_execute_query", 1, adbc_statement_execute_query, 0},
     {"adbc_statement_prepare", 1, adbc_statement_prepare, 0},
     {"adbc_statement_set_sql_query", 2, adbc_statement_set_sql_query, 0},

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -1037,7 +1037,7 @@ static ERL_NIF_TERM adbc_get_option(ErlNifEnv *env, const ERL_NIF_TERM argv[], G
     }
 
     std::string type, key;
-    if (!erlang::nif::get(env, argv[1], type)) {
+    if (!erlang::nif::get_atom(env, argv[1], type)) {
         return enif_make_badarg(env);
     }
     if (!erlang::nif::get(env, argv[2], key)) {

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -152,45 +152,24 @@ defmodule Adbc.Connection do
   end
 
   @doc """
-  Runs the given `query` with `params`.
+  Runs the given `query` with `params` and `statement_options`.
   """
-  @spec query(t(), binary | reference, [term]) :: {:ok, result_set} | {:error, Exception.t()}
-  def query(conn, query, params \\ [])
-      when (is_binary(query) or is_reference(query)) and is_list(params) do
-    stream(conn, {:query, query, params}, &stream_results/2)
-  end
-
-  @doc """
-  Same as `query/3` but raises an exception on error.
-  """
-  @spec query!(t(), binary | reference, [term]) :: result_set
-  def query!(conn, query, params \\ [])
-      when (is_binary(query) or is_reference(query)) and is_list(params) do
-    case query(conn, query, params) do
-      {:ok, result} -> result
-      {:error, reason} -> raise reason
-    end
-  end
-
-  @doc """
-  Runs the given `query` with `params`.
-  """
-  @spec query_with_options(t(), binary | reference, [term], Keyword.t()) ::
+  @spec query(t(), binary | reference, [term], Keyword.t()) ::
           {:ok, result_set} | {:error, Exception.t()}
-  def query_with_options(conn, query, params \\ [], statement_options)
+  def query(conn, query, params \\ [], statement_options \\ [])
       when (is_binary(query) or is_reference(query)) and is_list(params) and
              is_list(statement_options) do
     stream(conn, {:query, query, params, statement_options}, &stream_results/2)
   end
 
   @doc """
-  Same as `query_with_options/4` but raises an exception on error.
+  Same as `query/4` but raises an exception on error.
   """
-  @spec query_with_options!(t(), binary | reference, [term], Keyword.t()) :: result_set
-  def query_with_options!(conn, query, params \\ [], statement_options)
+  @spec query!(t(), binary | reference, [term], Keyword.t()) :: result_set
+  def query!(conn, query, params \\ [], statement_options \\ [])
       when (is_binary(query) or is_reference(query)) and is_list(params) and
              is_list(statement_options) do
-    case query_with_options(conn, query, params, statement_options) do
+    case query(conn, query, params, statement_options) do
       {:ok, result} -> result
       {:error, reason} -> raise reason
     end

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -95,11 +95,36 @@ defmodule Adbc.Connection do
 
   defp init_statement_options(ref, opts) do
     Enum.reduce_while(opts, :ok, fn {key, value}, :ok ->
-      case Adbc.Nif.adbc_statement_set_option(ref, to_string(key), to_string(value)) do
-        :ok -> {:cont, :ok}
-        {:error, _} = error -> {:halt, error}
-      end
+      init_statement_option(ref, key, value)
     end)
+  end
+
+  defp init_statement_option(ref, key, value) when is_binary(value) do
+    case Adbc.Nif.adbc_statement_set_option(ref, to_string(key), value) do
+      :ok -> {:cont, :ok}
+      {:error, _} = error -> {:halt, error}
+    end
+  end
+
+  defp init_statement_option(ref, key, {:bytes, value}) when is_binary(value) do
+    case Adbc.Nif.adbc_statement_set_option_bytes(ref, to_string(key), value) do
+      :ok -> {:cont, :ok}
+      {:error, _} = error -> {:halt, error}
+    end
+  end
+
+  defp init_statement_option(ref, key, value) when is_integer(value) do
+    case Adbc.Nif.adbc_statement_set_option_int(ref, to_string(key), value) do
+      :ok -> {:cont, :ok}
+      {:error, _} = error -> {:halt, error}
+    end
+  end
+
+  defp init_statement_option(ref, key, value) when is_float(value) do
+    case Adbc.Nif.adbc_statement_set_option_double(ref, to_string(key), value) do
+      :ok -> {:cont, :ok}
+      {:error, _} = error -> {:halt, error}
+    end
   end
 
   @doc """

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -58,8 +58,8 @@ defmodule Adbc.Connection do
   @doc """
   Get a string type option of the connection.
   """
-  @spec get_option(pid(), atom() | String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def get_option(conn, key) when is_pid(conn) do
+  @spec get_string_option(pid(), atom() | String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def get_string_option(conn, key) when is_pid(conn) do
     case GenServer.call(conn, {:get_option, to_string(key)}) do
       {:ok, value} ->
         {:ok, value}
@@ -70,10 +70,10 @@ defmodule Adbc.Connection do
   end
 
   @doc """
-  Get a bytes type option of the connection.
+  Get a binary (bytes) type option of the connection.
   """
-  @spec get_option_bytes(pid(), atom() | String.t()) :: {:ok, binary()} | {:error, String.t()}
-  def get_option_bytes(conn, key) when is_pid(conn) do
+  @spec get_binary_option(pid(), atom() | String.t()) :: {:ok, binary()} | {:error, String.t()}
+  def get_binary_option(conn, key) when is_pid(conn) do
     case GenServer.call(conn, {:get_option, :bytes, to_string(key)}) do
       {:ok, value} ->
         {:ok, value}
@@ -84,10 +84,10 @@ defmodule Adbc.Connection do
   end
 
   @doc """
-  Get an int type option of the connection.
+  Get an integer type option of the connection.
   """
-  @spec get_option_int(pid(), atom() | String.t()) :: {:ok, integer()} | {:error, String.t()}
-  def get_option_int(conn, key) when is_pid(conn) do
+  @spec get_integer_option(pid(), atom() | String.t()) :: {:ok, integer()} | {:error, String.t()}
+  def get_integer_option(conn, key) when is_pid(conn) do
     case GenServer.call(conn, {:get_option, :int, to_string(key)}) do
       {:ok, value} ->
         {:ok, value}
@@ -98,10 +98,10 @@ defmodule Adbc.Connection do
   end
 
   @doc """
-  Get a double type option of the connection.
+  Get a float type option of the connection.
   """
-  @spec get_option_double(pid(), atom() | String.t()) :: {:ok, float()} | {:error, String.t()}
-  def get_option_double(conn, key) when is_pid(conn) do
+  @spec get_float_option(pid(), atom() | String.t()) :: {:ok, float()} | {:error, String.t()}
+  def get_float_option(conn, key) when is_pid(conn) do
     case GenServer.call(conn, {:get_option, :double, to_string(key)}) do
       {:ok, value} ->
         {:ok, value}
@@ -112,11 +112,80 @@ defmodule Adbc.Connection do
   end
 
   @doc """
-  Set a string option of the connection.
+  Set option for the connection.
+
+  - If `value` is an atom or a string, then corresponding string option will be set.
+  - If `value` is a `{:byte, binary()}`-tuple, then corresponding binary option will be set.
+  - If `value` is an integer, then corresponding integer option will be set.
+  - If `value` is a float, then corresponding float option will be set.
   """
-  @spec set_option(pid(), atom() | String.t(), atom() | String.t() | number()) ::
+  @spec set_option(
+          pid(),
+          atom() | String.t(),
+          atom() | {:bytes, binary()} | String.t() | number()
+        ) ::
           :ok | {:error, String.t()}
   def set_option(conn, key, value) when is_pid(conn) do
+    case GenServer.call(conn, {:set_option, to_string(key), value}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
+    end
+  end
+
+  @doc """
+  Set a string type option for the connection.
+  """
+  @spec set_string_option(pid(), atom() | String.t(), term()) ::
+          :ok | {:error, String.t()}
+  def set_string_option(conn, key, value) when is_pid(conn) do
+    case GenServer.call(conn, {:set_option, to_string(key), to_string(value)}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
+    end
+  end
+
+  @doc """
+  Set a binary type option for the connection.
+  """
+  @spec set_binary_option(pid(), atom() | String.t(), binary()) ::
+          :ok | {:error, String.t()}
+  def set_binary_option(conn, key, value) when is_pid(conn) and is_binary(value) do
+    case GenServer.call(conn, {:set_option, to_string(key), {:bytes, value}}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
+    end
+  end
+
+  @doc """
+  Set an integer type option for the connection.
+  """
+  @spec set_integer_option(pid(), atom() | String.t(), integer()) ::
+          :ok | {:error, String.t()}
+  def set_integer_option(conn, key, value) when is_pid(conn) and is_integer(value) do
+    case GenServer.call(conn, {:set_option, to_string(key), value}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
+    end
+  end
+
+  @doc """
+  Set a float type option for the connection.
+  """
+  @spec set_float_option(pid(), atom() | String.t(), float()) ::
+          :ok | {:error, String.t()}
+  def set_float_option(conn, key, value) when is_pid(conn) and is_float(value) do
     case GenServer.call(conn, {:set_option, to_string(key), value}) do
       :ok ->
         :ok

--- a/lib/adbc_database.ex
+++ b/lib/adbc_database.ex
@@ -64,13 +64,7 @@ defmodule Adbc.Database do
   """
   @spec get_string_option(pid(), atom() | String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def get_string_option(db, key) when is_pid(db) do
-    case GenServer.call(db, {:get_option, :string, to_string(key)}) do
-      {:ok, value} ->
-        {:ok, value}
-
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
+    Adbc.Helper.option(db, :adbc_database_get_option, [:string, to_string(key)])
   end
 
   @doc """
@@ -78,13 +72,7 @@ defmodule Adbc.Database do
   """
   @spec get_binary_option(pid(), atom() | String.t()) :: {:ok, binary()} | {:error, String.t()}
   def get_binary_option(db, key) when is_pid(db) do
-    case GenServer.call(db, {:get_option, :bytes, to_string(key)}) do
-      {:ok, value} ->
-        {:ok, value}
-
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
+    Adbc.Helper.option(db, :adbc_database_get_option, [:binary, to_string(key)])
   end
 
   @doc """
@@ -92,13 +80,7 @@ defmodule Adbc.Database do
   """
   @spec get_integer_option(pid(), atom() | String.t()) :: {:ok, integer()} | {:error, String.t()}
   def get_integer_option(db, key) when is_pid(db) do
-    case GenServer.call(db, {:get_option, :int, to_string(key)}) do
-      {:ok, value} ->
-        {:ok, value}
-
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
+    Adbc.Helper.option(db, :adbc_database_get_option, [:integer, to_string(key)])
   end
 
   @doc """
@@ -106,97 +88,39 @@ defmodule Adbc.Database do
   """
   @spec get_float_option(pid(), atom() | String.t()) :: {:ok, float()} | {:error, String.t()}
   def get_float_option(db, key) when is_pid(db) do
-    case GenServer.call(db, {:get_option, :double, to_string(key)}) do
-      {:ok, value} ->
-        {:ok, value}
-
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
+    Adbc.Helper.option(db, :adbc_database_get_option, [:float, to_string(key)])
   end
 
   @doc """
-  Set option for the database.
+  Set option for the connection.
 
   - If `value` is an atom or a string, then corresponding string option will be set.
-  - If `value` is a `{:byte, binary()}`-tuple, then corresponding binary option will be set.
+  - If `value` is a `{:binary, binary()}`-tuple, then corresponding binary option will be set.
   - If `value` is an integer, then corresponding integer option will be set.
   - If `value` is a float, then corresponding float option will be set.
   """
   @spec set_option(
           pid(),
           atom() | String.t(),
-          atom() | {:bytes, binary()} | String.t() | number()
+          atom() | {:binary, binary()} | String.t() | number()
         ) ::
           :ok | {:error, String.t()}
-  def set_option(db, key, value) when is_pid(db) do
-    case GenServer.call(db, {:set_option, to_string(key), value}) do
-      :ok ->
-        :ok
+  def set_option(conn, key, value)
 
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
+  def set_option(conn, key, value) when is_pid(conn) and (is_atom(value) or is_binary(value)) do
+    Adbc.Helper.option(conn, :adbc_database_set_option, [:string, key, value])
   end
 
-  @doc """
-  Set a string type option for the database.
-  """
-  @spec set_string_option(pid(), atom() | String.t(), term()) ::
-          :ok | {:error, String.t()}
-  def set_string_option(db, key, value) when is_pid(db) do
-    case GenServer.call(db, {:set_option, to_string(key), to_string(value)}) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
+  def set_option(conn, key, {:binary, value}) when is_pid(conn) and is_binary(value) do
+    Adbc.Helper.option(conn, :adbc_database_set_option, [:binary, key, value])
   end
 
-  @doc """
-  Set a binary type option for the database.
-  """
-  @spec set_binary_option(pid(), atom() | String.t(), binary()) ::
-          :ok | {:error, String.t()}
-  def set_binary_option(db, key, value) when is_pid(db) and is_binary(value) do
-    case GenServer.call(db, {:set_option, to_string(key), {:bytes, value}}) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
+  def set_option(conn, key, value) when is_pid(conn) and is_integer(value) do
+    Adbc.Helper.option(conn, :adbc_database_set_option, [:integer, key, value])
   end
 
-  @doc """
-  Set an integer type option for the database.
-  """
-  @spec set_integer_option(pid(), atom() | String.t(), integer()) ::
-          :ok | {:error, String.t()}
-  def set_integer_option(db, key, value) when is_pid(db) and is_integer(value) do
-    case GenServer.call(db, {:set_option, to_string(key), value}) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
-  end
-
-  @doc """
-  Set a float type option for the database.
-  """
-  @spec set_float_option(pid(), atom() | String.t(), float()) ::
-          :ok | {:error, String.t()}
-  def set_float_option(db, key, value) when is_pid(db) and is_float(value) do
-    case GenServer.call(db, {:set_option, to_string(key), value}) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        {:error, error_to_exception(reason)}
-    end
+  def set_option(conn, key, value) when is_pid(conn) and is_float(value) do
+    Adbc.Helper.option(conn, :adbc_database_set_option, [:float, key, value])
   end
 
   defp driver_default_options(:duckdb), do: [entrypoint: "duckdb_adbc_init"]

--- a/lib/adbc_database.ex
+++ b/lib/adbc_database.ex
@@ -62,8 +62,8 @@ defmodule Adbc.Database do
   @doc """
   Get a string type option of the database.
   """
-  @spec get_option(pid(), atom() | String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def get_option(db, key) when is_pid(db) do
+  @spec get_string_option(pid(), atom() | String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def get_string_option(db, key) when is_pid(db) do
     case GenServer.call(db, {:get_option, :string, to_string(key)}) do
       {:ok, value} ->
         {:ok, value}
@@ -74,10 +74,10 @@ defmodule Adbc.Database do
   end
 
   @doc """
-  Get a bytes type option of the database.
+  Get a binary (bytes) type option of the database.
   """
-  @spec get_option_bytes(pid(), atom() | String.t()) :: {:ok, binary()} | {:error, String.t()}
-  def get_option_bytes(db, key) when is_pid(db) do
+  @spec get_binary_option(pid(), atom() | String.t()) :: {:ok, binary()} | {:error, String.t()}
+  def get_binary_option(db, key) when is_pid(db) do
     case GenServer.call(db, {:get_option, :bytes, to_string(key)}) do
       {:ok, value} ->
         {:ok, value}
@@ -88,10 +88,10 @@ defmodule Adbc.Database do
   end
 
   @doc """
-  Get an int type option of the database.
+  Get an integer type option of the database.
   """
-  @spec get_option_int(pid(), atom() | String.t()) :: {:ok, integer()} | {:error, String.t()}
-  def get_option_int(db, key) when is_pid(db) do
+  @spec get_integer_option(pid(), atom() | String.t()) :: {:ok, integer()} | {:error, String.t()}
+  def get_integer_option(db, key) when is_pid(db) do
     case GenServer.call(db, {:get_option, :int, to_string(key)}) do
       {:ok, value} ->
         {:ok, value}
@@ -102,10 +102,10 @@ defmodule Adbc.Database do
   end
 
   @doc """
-  Get a double type option of the database.
+  Get a float type option of the database.
   """
-  @spec get_option_double(pid(), atom() | String.t()) :: {:ok, float()} | {:error, String.t()}
-  def get_option_double(db, key) when is_pid(db) do
+  @spec get_float_option(pid(), atom() | String.t()) :: {:ok, float()} | {:error, String.t()}
+  def get_float_option(db, key) when is_pid(db) do
     case GenServer.call(db, {:get_option, :double, to_string(key)}) do
       {:ok, value} ->
         {:ok, value}
@@ -116,12 +116,81 @@ defmodule Adbc.Database do
   end
 
   @doc """
-  Set a string option of the database.
+  Set option for the database.
+
+  - If `value` is an atom or a string, then corresponding string option will be set.
+  - If `value` is a `{:byte, binary()}`-tuple, then corresponding binary option will be set.
+  - If `value` is an integer, then corresponding integer option will be set.
+  - If `value` is a float, then corresponding float option will be set.
   """
-  @spec set_option(pid(), atom() | String.t(), atom() | String.t() | number()) ::
+  @spec set_option(
+          pid(),
+          atom() | String.t(),
+          atom() | {:bytes, binary()} | String.t() | number()
+        ) ::
           :ok | {:error, String.t()}
   def set_option(db, key, value) when is_pid(db) do
-    case GenServer.call(db, {:set_option, key, value}) do
+    case GenServer.call(db, {:set_option, to_string(key), value}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
+    end
+  end
+
+  @doc """
+  Set a string type option for the database.
+  """
+  @spec set_string_option(pid(), atom() | String.t(), term()) ::
+          :ok | {:error, String.t()}
+  def set_string_option(db, key, value) when is_pid(db) do
+    case GenServer.call(db, {:set_option, to_string(key), to_string(value)}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
+    end
+  end
+
+  @doc """
+  Set a binary type option for the database.
+  """
+  @spec set_binary_option(pid(), atom() | String.t(), binary()) ::
+          :ok | {:error, String.t()}
+  def set_binary_option(db, key, value) when is_pid(db) and is_binary(value) do
+    case GenServer.call(db, {:set_option, to_string(key), {:bytes, value}}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
+    end
+  end
+
+  @doc """
+  Set an integer type option for the database.
+  """
+  @spec set_integer_option(pid(), atom() | String.t(), integer()) ::
+          :ok | {:error, String.t()}
+  def set_integer_option(db, key, value) when is_pid(db) and is_integer(value) do
+    case GenServer.call(db, {:set_option, to_string(key), value}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
+    end
+  end
+
+  @doc """
+  Set a float type option for the database.
+  """
+  @spec set_float_option(pid(), atom() | String.t(), float()) ::
+          :ok | {:error, String.t()}
+  def set_float_option(db, key, value) when is_pid(db) and is_float(value) do
+    case GenServer.call(db, {:set_option, to_string(key), value}) do
       :ok ->
         :ok
 

--- a/lib/adbc_helper.ex
+++ b/lib/adbc_helper.ex
@@ -14,107 +14,32 @@ defmodule Adbc.Helper do
     Adbc.Error.exception(message: message, vendor_code: vendor_code, state: state)
   end
 
-  def get_option(type, :string, ref, key) do
-    case type do
-      :statement ->
-        Adbc.Nif.adbc_statement_get_option(ref, to_string(key))
+  def error_to_exception(%Adbc.Error{} = exception) do
+    exception
+  end
 
-      :connection ->
-        Adbc.Nif.adbc_connection_get_option(ref, to_string(key))
+  def option(callee, func, args)
 
-      :database ->
-        Adbc.Nif.adbc_database_get_option(ref, to_string(key))
+  def option(pid, func, args) when is_pid(pid) do
+    case GenServer.call(pid, {:option, func, args}) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, error_to_exception(reason)}
     end
   end
 
-  def get_option(type, :bytes, ref, key) do
-    case type do
-      :statement ->
-        Adbc.Nif.adbc_statement_get_option_bytes(ref, to_string(key))
-
-      :connection ->
-        Adbc.Nif.adbc_connection_get_option_bytes(ref, to_string(key))
-
-      :database ->
-        Adbc.Nif.adbc_database_get_option_bytes(ref, to_string(key))
+  def option(ref, func, [type, key | args]) when is_reference(ref) do
+    with {:error, reason} <- apply(Adbc.Nif, func, [ref, type, to_string(key) | args]) do
+      {:error, error_to_exception(reason)}
     end
   end
 
-  def get_option(type, :int, ref, key) do
-    case type do
-      :statement ->
-        Adbc.Nif.adbc_statement_get_option_int(ref, to_string(key))
-
-      :connection ->
-        Adbc.Nif.adbc_connection_get_option_int(ref, to_string(key))
-
-      :database ->
-        Adbc.Nif.adbc_database_get_option_int(ref, to_string(key))
-    end
-  end
-
-  def get_option(type, :double, ref, key) do
-    case type do
-      :statement ->
-        Adbc.Nif.adbc_statement_get_option_double(ref, to_string(key))
-
-      :connection ->
-        Adbc.Nif.adbc_connection_get_option_double(ref, to_string(key))
-
-      :database ->
-        Adbc.Nif.adbc_database_get_option_double(ref, to_string(key))
-    end
-  end
-
-  def set_option(type, ref, key, value) when is_binary(value) or is_atom(value) do
-    case type do
-      :statement ->
-        Adbc.Nif.adbc_statement_set_option(ref, to_string(key), to_string(value))
-
-      :connection ->
-        Adbc.Nif.adbc_connection_set_option(ref, to_string(key), to_string(value))
-
-      :database ->
-        Adbc.Nif.adbc_database_set_option(ref, to_string(key), to_string(value))
-    end
-  end
-
-  def set_option(type, ref, key, {:bytes, value}) when is_binary(value) do
-    case type do
-      :statement ->
-        Adbc.Nif.adbc_statement_set_option_bytes(ref, to_string(key), value)
-
-      :connection ->
-        Adbc.Nif.adbc_connection_set_option_bytes(ref, to_string(key), value)
-
-      :database ->
-        Adbc.Nif.adbc_database_set_option_bytes(ref, to_string(key), value)
-    end
-  end
-
-  def set_option(type, ref, key, value) when is_integer(value) do
-    case type do
-      :statement ->
-        Adbc.Nif.adbc_statement_set_option_int(ref, to_string(key), value)
-
-      :connection ->
-        Adbc.Nif.adbc_connection_set_option_int(ref, to_string(key), value)
-
-      :database ->
-        Adbc.Nif.adbc_database_set_option_int(ref, to_string(key), value)
-    end
-  end
-
-  def set_option(type, ref, key, value) when is_float(value) do
-    case type do
-      :statement ->
-        Adbc.Nif.adbc_statement_set_option_double(ref, to_string(key), value)
-
-      :connection ->
-        Adbc.Nif.adbc_connection_set_option_double(ref, to_string(key), value)
-
-      :database ->
-        Adbc.Nif.adbc_database_set_option_double(ref, to_string(key), value)
+  def option_ok_or_halt(callee, func, args) do
+    case option(callee, func, args) do
+      :ok -> {:cont, :ok}
+      {:error, _} = error -> {:halt, error}
     end
   end
 

--- a/lib/adbc_helper.ex
+++ b/lib/adbc_helper.ex
@@ -14,6 +14,110 @@ defmodule Adbc.Helper do
     Adbc.Error.exception(message: message, vendor_code: vendor_code, state: state)
   end
 
+  def get_option(type, :string, ref, key) do
+    case type do
+      :statement ->
+        Adbc.Nif.adbc_statement_get_option(ref, to_string(key))
+
+      :connection ->
+        Adbc.Nif.adbc_connection_get_option(ref, to_string(key))
+
+      :database ->
+        Adbc.Nif.adbc_database_get_option(ref, to_string(key))
+    end
+  end
+
+  def get_option(type, :bytes, ref, key) do
+    case type do
+      :statement ->
+        Adbc.Nif.adbc_statement_get_option_bytes(ref, to_string(key))
+
+      :connection ->
+        Adbc.Nif.adbc_connection_get_option_bytes(ref, to_string(key))
+
+      :database ->
+        Adbc.Nif.adbc_database_get_option_bytes(ref, to_string(key))
+    end
+  end
+
+  def get_option(type, :int, ref, key) do
+    case type do
+      :statement ->
+        Adbc.Nif.adbc_statement_get_option_int(ref, to_string(key))
+
+      :connection ->
+        Adbc.Nif.adbc_connection_get_option_int(ref, to_string(key))
+
+      :database ->
+        Adbc.Nif.adbc_database_get_option_int(ref, to_string(key))
+    end
+  end
+
+  def get_option(type, :double, ref, key) do
+    case type do
+      :statement ->
+        Adbc.Nif.adbc_statement_get_option_double(ref, to_string(key))
+
+      :connection ->
+        Adbc.Nif.adbc_connection_get_option_double(ref, to_string(key))
+
+      :database ->
+        Adbc.Nif.adbc_database_get_option_double(ref, to_string(key))
+    end
+  end
+
+  def set_option(type, ref, key, value) when is_binary(value) or is_atom(value) do
+    case type do
+      :statement ->
+        Adbc.Nif.adbc_statement_set_option(ref, to_string(key), to_string(value))
+
+      :connection ->
+        Adbc.Nif.adbc_connection_set_option(ref, to_string(key), to_string(value))
+
+      :database ->
+        Adbc.Nif.adbc_database_set_option(ref, to_string(key), to_string(value))
+    end
+  end
+
+  def set_option(type, ref, key, {:bytes, value}) when is_binary(value) do
+    case type do
+      :statement ->
+        Adbc.Nif.adbc_statement_set_option_bytes(ref, to_string(key), value)
+
+      :connection ->
+        Adbc.Nif.adbc_connection_set_option_bytes(ref, to_string(key), value)
+
+      :database ->
+        Adbc.Nif.adbc_database_set_option_bytes(ref, to_string(key), value)
+    end
+  end
+
+  def set_option(type, ref, key, value) when is_integer(value) do
+    case type do
+      :statement ->
+        Adbc.Nif.adbc_statement_set_option_int(ref, to_string(key), value)
+
+      :connection ->
+        Adbc.Nif.adbc_connection_set_option_int(ref, to_string(key), value)
+
+      :database ->
+        Adbc.Nif.adbc_database_set_option_int(ref, to_string(key), value)
+    end
+  end
+
+  def set_option(type, ref, key, value) when is_float(value) do
+    case type do
+      :statement ->
+        Adbc.Nif.adbc_statement_set_option_double(ref, to_string(key), value)
+
+      :connection ->
+        Adbc.Nif.adbc_connection_set_option_double(ref, to_string(key), value)
+
+      :database ->
+        Adbc.Nif.adbc_database_set_option_double(ref, to_string(key), value)
+    end
+  end
+
   @doc false
   def download(url, ignore_proxy) do
     url_charlist = String.to_charlist(url)

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -23,41 +23,17 @@ defmodule Adbc.Nif do
 
   def adbc_database_new, do: :erlang.nif_error(:not_loaded)
 
-  def adbc_database_get_option(_self, _key), do: :erlang.nif_error(:not_loaded)
+  def adbc_database_get_option(_self, _type, _key), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_database_get_option_bytes(_self, _key), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_database_get_option_int(_self, _key), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_database_get_option_double(_self, _key), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_database_set_option(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_database_set_option_bytes(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_database_set_option_int(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_database_set_option_double(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
+  def adbc_database_set_option(_self, _type, _key, _value), do: :erlang.nif_error(:not_loaded)
 
   def adbc_database_init(_self), do: :erlang.nif_error(:not_loaded)
 
   def adbc_connection_new, do: :erlang.nif_error(:not_loaded)
 
-  def adbc_connection_get_option(_self, _key), do: :erlang.nif_error(:not_loaded)
+  def adbc_connection_get_option(_self, _type, _key), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_connection_get_option_bytes(_self, _key), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_connection_get_option_int(_self, _key), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_connection_get_option_double(_self, _key), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_connection_set_option(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_connection_set_option_bytes(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_connection_set_option_int(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_connection_set_option_double(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
+  def adbc_connection_set_option(_self, _type, _key, _value), do: :erlang.nif_error(:not_loaded)
 
   def adbc_connection_init(_self, _database), do: :erlang.nif_error(:not_loaded)
 
@@ -76,35 +52,21 @@ defmodule Adbc.Nif do
 
   def adbc_connection_get_table_types(_self), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_new(_statement), do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_new(_self), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_get_option(_statement, _key), do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_get_option(_self, _type, _key), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_get_option_bytes(_statement, _key), do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_set_option(_self, _type, _key, _value), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_get_option_int(_statement, _key), do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_execute_query(_self), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_get_option_double(_statement, _key), do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_prepare(_self), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_set_option(_statement, _key, _value), do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_set_sql_query(_self, _query), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_set_option_bytes(_statement, _key, _value),
-    do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_bind(_self, _values), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_set_option_int(_statement, _key, _value), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_statement_set_option_double(_statement, _key, _value),
-    do: :erlang.nif_error(:not_loaded)
-
-  def adbc_statement_execute_query(_statement), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_statement_prepare(_statement), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_statement_set_sql_query(_statement, _query), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_statement_bind(_statement, _values), do: :erlang.nif_error(:not_loaded)
-
-  def adbc_statement_bind_stream(_statement, _stream), do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_bind_stream(_self, _stream), do: :erlang.nif_error(:not_loaded)
 
   def adbc_arrow_array_stream_get_pointer(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
 

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -23,6 +23,8 @@ defmodule Adbc.Nif do
 
   def adbc_database_new, do: :erlang.nif_error(:not_loaded)
 
+  def adbc_database_get_option(_self, _key), do: :erlang.nif_error(:not_loaded)
+
   def adbc_database_set_option(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
 
   def adbc_database_init(_self), do: :erlang.nif_error(:not_loaded)

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -31,6 +31,8 @@ defmodule Adbc.Nif do
 
   def adbc_connection_new, do: :erlang.nif_error(:not_loaded)
 
+  def adbc_connection_get_option(_self, _key), do: :erlang.nif_error(:not_loaded)
+
   def adbc_connection_set_option(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
 
   def adbc_connection_init(_self, _database), do: :erlang.nif_error(:not_loaded)

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -25,7 +25,19 @@ defmodule Adbc.Nif do
 
   def adbc_database_get_option(_self, _key), do: :erlang.nif_error(:not_loaded)
 
+  def adbc_database_get_option_bytes(_self, _key), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_database_get_option_int(_self, _key), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_database_get_option_double(_self, _key), do: :erlang.nif_error(:not_loaded)
+
   def adbc_database_set_option(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_database_set_option_bytes(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_database_set_option_int(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_database_set_option_double(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
 
   def adbc_database_init(_self), do: :erlang.nif_error(:not_loaded)
 
@@ -33,7 +45,19 @@ defmodule Adbc.Nif do
 
   def adbc_connection_get_option(_self, _key), do: :erlang.nif_error(:not_loaded)
 
+  def adbc_connection_get_option_bytes(_self, _key), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_connection_get_option_int(_self, _key), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_connection_get_option_double(_self, _key), do: :erlang.nif_error(:not_loaded)
+
   def adbc_connection_set_option(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_connection_set_option_bytes(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_connection_set_option_int(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_connection_set_option_double(_self, _key, _value), do: :erlang.nif_error(:not_loaded)
 
   def adbc_connection_init(_self, _database), do: :erlang.nif_error(:not_loaded)
 
@@ -53,6 +77,14 @@ defmodule Adbc.Nif do
   def adbc_connection_get_table_types(_self), do: :erlang.nif_error(:not_loaded)
 
   def adbc_statement_new(_statement), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_statement_get_option(_statement, _key), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_statement_get_option_bytes(_statement, _key), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_statement_get_option_int(_statement, _key), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_statement_get_option_double(_statement, _key), do: :erlang.nif_error(:not_loaded)
 
   def adbc_statement_set_option(_statement, _key, _value), do: :erlang.nif_error(:not_loaded)
 

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -52,7 +52,9 @@ defmodule Adbc.Nif do
 
   def adbc_connection_get_table_types(_self), do: :erlang.nif_error(:not_loaded)
 
-  def adbc_statement_new(_connection), do: :erlang.nif_error(:not_loaded)
+  def adbc_statement_new(_statement), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_statement_set_option(_statement, _key, _value), do: :erlang.nif_error(:not_loaded)
 
   def adbc_statement_execute_query(_statement), do: :erlang.nif_error(:not_loaded)
 

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -56,6 +56,14 @@ defmodule Adbc.Nif do
 
   def adbc_statement_set_option(_statement, _key, _value), do: :erlang.nif_error(:not_loaded)
 
+  def adbc_statement_set_option_bytes(_statement, _key, _value),
+    do: :erlang.nif_error(:not_loaded)
+
+  def adbc_statement_set_option_int(_statement, _key, _value), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_statement_set_option_double(_statement, _key, _value),
+    do: :erlang.nif_error(:not_loaded)
+
   def adbc_statement_execute_query(_statement), do: :erlang.nif_error(:not_loaded)
 
   def adbc_statement_prepare(_statement), do: :erlang.nif_error(:not_loaded)

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -235,7 +235,7 @@ defmodule Adbc.Connection.Test do
       conn = start_supervised!({Connection, database: db})
 
       assert %Adbc.Result{data: %{"num" => [123], "bool" => [1]}} ==
-               Connection.query_with_options!(conn, "SELECT 123 as num, true as bool",
+               Connection.query!(conn, "SELECT 123 as num, true as bool", [],
                  "adbc.sqlite.query.batch_rows": 1
                )
     end
@@ -244,7 +244,7 @@ defmodule Adbc.Connection.Test do
       conn = start_supervised!({Connection, database: db})
 
       assert %Adbc.Result{data: %{"num" => [579]}} ==
-               Connection.query_with_options!(conn, "SELECT 123 + ? as num", [456],
+               Connection.query!(conn, "SELECT 123 + ? as num", [456],
                  "adbc.sqlite.query.batch_rows": 10
                )
     end
@@ -253,7 +253,7 @@ defmodule Adbc.Connection.Test do
       conn = start_supervised!({Connection, database: db})
 
       assert {:error, %Adbc.Error{} = error} =
-               Connection.query_with_options(conn, "SELECT 123 as num", foo: 1)
+               Connection.query(conn, "SELECT 123 as num", [], foo: 1)
 
       assert Exception.message(error) == "[SQLite] Unknown statement option foo=1"
     end
@@ -262,7 +262,7 @@ defmodule Adbc.Connection.Test do
       conn = start_supervised!({Connection, database: db})
 
       assert {:error, %Adbc.Error{} = error} =
-               Connection.query_with_options(conn, "SELECT 123 as num, true as bool",
+               Connection.query(conn, "SELECT 123 as num, true as bool", [],
                  "adbc.sqlite.query.batch_rows": 0
                )
 

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -36,7 +36,7 @@ defmodule Adbc.Connection.Test do
 
       assert {:error, %Adbc.Error{} = error} = Connection.start_link(database: db, who_knows: 123)
 
-      assert Exception.message(error) == "[SQLite] Unknown connection option who_knows='123'"
+      assert Exception.message(error) == "[SQLite] Unknown connection option who_knows=123"
     end
   end
 

--- a/test/adbc_database_test.exs
+++ b/test/adbc_database_test.exs
@@ -30,7 +30,7 @@ defmodule Adbc.DatabaseTest do
       assert {:error, %Adbc.Error{} = error} =
                Database.start_link(driver: :sqlite, who_knows: 123)
 
-      assert Exception.message(error) == "[SQLite] Unknown database option who_knows='123'"
+      assert Exception.message(error) == "[SQLite] Unknown database option who_knows=123"
     end
   end
 end

--- a/test/adbc_database_test.exs
+++ b/test/adbc_database_test.exs
@@ -33,4 +33,18 @@ defmodule Adbc.DatabaseTest do
       assert Exception.message(error) == "[SQLite] Unknown database option who_knows=123"
     end
   end
+
+  describe "get/set options" do
+    test "get non-existed option" do
+      {:ok, pid} = Database.start_link(driver: :sqlite)
+      assert {:error, %Adbc.Error{} = error} = Database.get_string_option(pid, "foo")
+      assert Exception.message(error) == "Unknown option"
+    end
+
+    test "set non-existed option" do
+      {:ok, pid} = Database.start_link(driver: :sqlite)
+      assert {:error, %Adbc.Error{} = error} = Database.set_option(pid, "foo", "bar")
+      assert Exception.message(error) == "[SQLite] Unknown database option foo='bar'"
+    end
+  end
 end


### PR DESCRIPTION
Based on the design of ADBC, we probably have to expose more APIs, in particular these `{get,set}_option` functions. This PR added the following functions

```elixir
Adbc.Database.get_option/2
Adbc.Database.set_option/3
Adbc.Connection.get_option/2
Adbc.Connection.set_option/3
Adbc.Connection.query_with_options/4
Adbc.Connection.query_with_options!/4
```

`Adbc.Connection.query_with_options/4` will call `Adbc.Nif.adbc_statement_set_option/3` in `create_statement`. Users can now send query with statement options using:

```elixir
db = start_supervised!({Adbc.Database, driver: :some_driver})
conn = start_supervised!({Connection, database: db})

# with parameters
query_result = Connection.query_with_options(conn, 
  "SOME SQL STATEMENT BIND WITH ?", 
  ["PARAMETERS"],
  statement_option_a: "value for a",
  statement_option_b: "value for b",
)

# without parameters
query_result = Connection.query_with_options(conn, 
  "SOME SQL STATEMENT",
  statement_option_a: "value for a",
  statement_option_b: "value for b",
)
```