### PR TITLE
feat: support bind named parameters via `Adbc.Buffer`

### DIFF
--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -1816,27 +1816,27 @@ int adbc_buffer_to_arrow_type_struct(ErlNifEnv *env, ERL_NIF_TERM values, struct
         auto child_i = array_out->children[processed];
         adbc_buffer_to_adbc_field(env, head, child_i, schema_i, error_out);
 
-        // ErlNifSInt64 i64;
-        // double f64;
-        // ErlNifBinary bytes;
+        ErlNifSInt64 i64;
+        double f64;
+        ErlNifBinary bytes;
 
-        // if (enif_get_int64(env, head, &i64)) {
-        //     NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema_i, NANOARROW_TYPE_INT64));
-        //     NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema_i, ""));
-        //     NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromSchema(child_i, schema_i, error_out));
-        //     NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(child_i));
-        //     NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(child_i, i64));
-        // } else if (enif_get_double(env, head, &f64)) {
-        //     NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema_i, NANOARROW_TYPE_DOUBLE));
-        //     NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema_i, ""));
-        //     NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromSchema(child_i, schema_i, error_out));
-        //     NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(child_i));
-        //     NANOARROW_RETURN_NOT_OK(ArrowArrayAppendDouble(child_i, f64));
-        // } else if (enif_is_binary(env, head) && enif_inspect_binary(env, head, &bytes)) {
-        //     auto type = NANOARROW_TYPE_BINARY;
-        //     if (bytes.size > INT32_MAX) {
-        //         type = NANOARROW_TYPE_LARGE_BINARY;
-        //     }
+        if (enif_get_int64(env, head, &i64)) {
+            NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema_i, NANOARROW_TYPE_INT64));
+            NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema_i, ""));
+            NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromSchema(child_i, schema_i, error_out));
+            NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(child_i));
+            NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(child_i, i64));
+        } else if (enif_get_double(env, head, &f64)) {
+            NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema_i, NANOARROW_TYPE_DOUBLE));
+            NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema_i, ""));
+            NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromSchema(child_i, schema_i, error_out));
+            NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(child_i));
+            NANOARROW_RETURN_NOT_OK(ArrowArrayAppendDouble(child_i, f64));
+        } else if (enif_is_binary(env, head) && enif_inspect_binary(env, head, &bytes)) {
+            auto type = NANOARROW_TYPE_BINARY;
+            if (bytes.size > INT32_MAX) {
+                type = NANOARROW_TYPE_LARGE_BINARY;
+            }
 
             struct ArrowBufferView view{};
             view.data.data = bytes.data;

--- a/lib/adbc_buffer.ex
+++ b/lib/adbc_buffer.ex
@@ -25,7 +25,7 @@ defmodule Adbc.Buffer do
   defstruct name: nil,
             type: nil,
             nullable: false,
-            metadata: nil,
+            metadata: %{},
             data: nil
 
   @spec buffer(atom, list, Keyword.t()) :: %Adbc.Buffer{}
@@ -41,6 +41,29 @@ defmodule Adbc.Buffer do
       metadata: metadata,
       data: data
     }
+  end
+
+  @spec get_metadata(%Adbc.Buffer{}, String.t(), String.t()) :: String.t() | nil
+  def get_metadata(%Adbc.Buffer{metadata: metadata}, key, default \\ nil)
+      when is_binary(key) or is_atom(key) do
+    metadata[to_string(key)] || default
+  end
+
+  @spec set_metadata(%Adbc.Buffer{}, String.t(), String.t()) :: %Adbc.Buffer{}
+  def set_metadata(buffer = %Adbc.Buffer{metadata: metadata}, key, value)
+      when (is_binary(key) or is_atom(key)) and (is_binary(value) or is_atom(value)) do
+    %Adbc.Buffer{buffer | metadata: Map.put(metadata, to_string(key), to_string(value))}
+  end
+
+  @spec delete_metadata(%Adbc.Buffer{}, String.t()) :: %Adbc.Buffer{}
+  def delete_metadata(buffer = %Adbc.Buffer{metadata: metadata}, key)
+      when is_binary(key) or is_atom(key) do
+    %Adbc.Buffer{buffer | metadata: Map.delete(metadata, to_string(key))}
+  end
+
+  @spec delete_all_metadata(%Adbc.Buffer{}) :: %Adbc.Buffer{}
+  def delete_all_metadata(buffer = %Adbc.Buffer{})
+    %Adbc.Buffer{buffer | metadata: %{}}
   end
 
   @spec boolean([0..255], Keyword.t()) :: %Adbc.Buffer{}

--- a/lib/adbc_buffer.ex
+++ b/lib/adbc_buffer.ex
@@ -1,4 +1,27 @@
 defmodule Adbc.Buffer do
+  @moduledoc """
+  Documentation for `Adbc.Buffer`.
+
+  One `Adbc.Buffer` corresponds to a column in the table. It contains the column's name, type, and
+  data. The data is a list of values of the column's type. The type can be one of the following:
+
+  * `:boolean`
+  * `:u8`
+  * `:u16`
+  * `:u32`
+  * `:u64`
+  * `:i8`
+  * `:i16`
+  * `:i32`
+  * `:i64`
+  * `:f32`
+  * `:f64`
+  * `:string`
+  * `:large_string`, when the size of the string is larger than 4GB
+  * `:binary`
+  * `:large_binary`, when the size of the binary is larger than 4GB
+  * `:fixed_size_binary`
+  """
   defstruct name: nil,
             type: nil,
             nullable: false,
@@ -94,5 +117,10 @@ defmodule Adbc.Buffer do
   @spec large_binary([binary()], Keyword.t()) :: %Adbc.Buffer{}
   def large_binary(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:large_binary, data, opts)
+  end
+
+  @spec fixed_size_binary([binary()], Keyword.t()) :: %Adbc.Buffer{}
+  def fixed_size_binary(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:fixed_size_binary, data, opts)
   end
 end

--- a/lib/adbc_buffer.ex
+++ b/lib/adbc_buffer.ex
@@ -62,7 +62,7 @@ defmodule Adbc.Buffer do
   end
 
   @spec delete_all_metadata(%Adbc.Buffer{}) :: %Adbc.Buffer{}
-  def delete_all_metadata(buffer = %Adbc.Buffer{})
+  def delete_all_metadata(buffer = %Adbc.Buffer{}) do
     %Adbc.Buffer{buffer | metadata: %{}}
   end
 

--- a/lib/adbc_buffer.ex
+++ b/lib/adbc_buffer.ex
@@ -1,17 +1,16 @@
 defmodule Adbc.Buffer do
-  defstruct [
-    name: nil,
-    type: nil,
-    nullable: nil,
-    metadata: nil,
-    data: nil,
-  ]
+  defstruct name: nil,
+            type: nil,
+            nullable: false,
+            metadata: nil,
+            data: nil
 
   @spec buffer(atom, list, Keyword.t()) :: %Adbc.Buffer{}
   def buffer(type, data, opts \\ []) when is_atom(type) and is_list(data) and is_list(opts) do
     name = opts[:name]
-    nullable = opts[:nullable]
+    nullable = opts[:nullable] || false
     metadata = opts[:metadata]
+
     %Adbc.Buffer{
       name: name,
       type: type,
@@ -21,22 +20,27 @@ defmodule Adbc.Buffer do
     }
   end
 
+  @spec boolean([0..255], Keyword.t()) :: %Adbc.Buffer{}
+  def boolean(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:boolean, data, opts)
+  end
+
   @spec u8([0..255], Keyword.t()) :: %Adbc.Buffer{}
   def u8(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:u8, data, opts)
   end
 
   @spec u16([0..65535], Keyword.t()) :: %Adbc.Buffer{}
-  def u16(data, opts \\ []) when is_list(data) and is_list(opts)  do
+  def u16(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:u16, data, opts)
   end
 
-  @spec u32([0..4294967295], Keyword.t()) :: %Adbc.Buffer{}
+  @spec u32([0..4_294_967_295], Keyword.t()) :: %Adbc.Buffer{}
   def u32(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:u32, data, opts)
   end
 
-  @spec u64([0..18446744073709551615], Keyword.t()) :: %Adbc.Buffer{}
+  @spec u64([0..18_446_744_073_709_551_615], Keyword.t()) :: %Adbc.Buffer{}
   def u64(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:u64, data, opts)
   end
@@ -51,12 +55,13 @@ defmodule Adbc.Buffer do
     buffer(:i16, data, opts)
   end
 
-  @spec i32([-2147483648..2147483647], Keyword.t()) :: %Adbc.Buffer{}
+  @spec i32([-2_147_483_648..2_147_483_647], Keyword.t()) :: %Adbc.Buffer{}
   def i32(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:i32, data, opts)
   end
 
-  @spec i64([-9223372036854775808..9223372036854775807], Keyword.t()) :: %Adbc.Buffer{}
+  @spec i64([-9_223_372_036_854_775_808..9_223_372_036_854_775_807], Keyword.t()) ::
+          %Adbc.Buffer{}
   def i64(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:i64, data, opts)
   end
@@ -76,8 +81,18 @@ defmodule Adbc.Buffer do
     buffer(:string, data, opts)
   end
 
+  @spec large_string([String.t()], Keyword.t()) :: %Adbc.Buffer{}
+  def large_string(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:large_string, data, opts)
+  end
+
   @spec binary([binary()], Keyword.t()) :: %Adbc.Buffer{}
   def binary(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:binary, data, opts)
+  end
+
+  @spec large_binary([binary()], Keyword.t()) :: %Adbc.Buffer{}
+  def large_binary(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:large_binary, data, opts)
   end
 end

--- a/lib/adbc_buffer.ex
+++ b/lib/adbc_buffer.ex
@@ -66,7 +66,7 @@ defmodule Adbc.Buffer do
     %Adbc.Buffer{buffer | metadata: %{}}
   end
 
-  @spec boolean([0..255], Keyword.t()) :: %Adbc.Buffer{}
+  @spec boolean([boolean()], Keyword.t()) :: %Adbc.Buffer{}
   def boolean(data, opts \\ []) when is_list(data) and is_list(opts) do
     buffer(:boolean, data, opts)
   end

--- a/lib/adbc_buffer.ex
+++ b/lib/adbc_buffer.ex
@@ -1,0 +1,83 @@
+defmodule Adbc.Buffer do
+  defstruct [
+    name: nil,
+    type: nil,
+    nullable: nil,
+    metadata: nil,
+    data: nil,
+  ]
+
+  @spec buffer(atom, list, Keyword.t()) :: %Adbc.Buffer{}
+  def buffer(type, data, opts \\ []) when is_atom(type) and is_list(data) and is_list(opts) do
+    name = opts[:name]
+    nullable = opts[:nullable]
+    metadata = opts[:metadata]
+    %Adbc.Buffer{
+      name: name,
+      type: type,
+      nullable: nullable,
+      metadata: metadata,
+      data: data
+    }
+  end
+
+  @spec u8([0..255], Keyword.t()) :: %Adbc.Buffer{}
+  def u8(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:u8, data, opts)
+  end
+
+  @spec u16([0..65535], Keyword.t()) :: %Adbc.Buffer{}
+  def u16(data, opts \\ []) when is_list(data) and is_list(opts)  do
+    buffer(:u16, data, opts)
+  end
+
+  @spec u32([0..4294967295], Keyword.t()) :: %Adbc.Buffer{}
+  def u32(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:u32, data, opts)
+  end
+
+  @spec u64([0..18446744073709551615], Keyword.t()) :: %Adbc.Buffer{}
+  def u64(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:u64, data, opts)
+  end
+
+  @spec i8([-128..127], Keyword.t()) :: %Adbc.Buffer{}
+  def i8(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:i8, data, opts)
+  end
+
+  @spec i16([-32768..32767], Keyword.t()) :: %Adbc.Buffer{}
+  def i16(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:i16, data, opts)
+  end
+
+  @spec i32([-2147483648..2147483647], Keyword.t()) :: %Adbc.Buffer{}
+  def i32(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:i32, data, opts)
+  end
+
+  @spec i64([-9223372036854775808..9223372036854775807], Keyword.t()) :: %Adbc.Buffer{}
+  def i64(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:i64, data, opts)
+  end
+
+  @spec f32([float], Keyword.t()) :: %Adbc.Buffer{}
+  def f32(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:f32, data, opts)
+  end
+
+  @spec f64([float], Keyword.t()) :: %Adbc.Buffer{}
+  def f64(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:f64, data, opts)
+  end
+
+  @spec string([String.t()], Keyword.t()) :: %Adbc.Buffer{}
+  def string(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:string, data, opts)
+  end
+
+  @spec binary([binary()], Keyword.t()) :: %Adbc.Buffer{}
+  def binary(data, opts \\ []) when is_list(data) and is_list(opts) do
+    buffer(:binary, data, opts)
+  end
+end

--- a/test/adbc_sqlite_test.exs
+++ b/test/adbc_sqlite_test.exs
@@ -1,0 +1,185 @@
+defmodule Adbc.SQLite.Test do
+  use ExUnit.Case
+
+  alias Adbc.Connection
+
+  setup do
+    db = start_supervised!({Adbc.Database, driver: :sqlite, uri: ":memory:"})
+    conn = start_supervised!({Connection, database: db})
+
+    Connection.query(conn, """
+    CREATE TABLE test (
+      i1 INT,
+      i2 INTEGER,
+      i3 TINYINT,
+      i4 SMALLINT,
+      i5 MEDIUMINT,
+      i6 BIGINT,
+      i7 UNSIGNED BIG INT,
+      i8 INT2,
+      i9 INT8,
+      t1 CHARACTER(10),
+      t2 VARCHAR(10),
+      t3 NCHAR(10),
+      t4 NVARCHAR(10),
+      t5 TEXT,
+      t6 CLOB,
+      b1 BLOB,
+      r1 REAL,
+      r2 DOUBLE,
+      r3 DOUBLE PRECISION,
+      r4 FLOAT,
+      n1 NUMERIC,
+      n2 DECIMAL(10,5),
+      n3 BOOLEAN,
+      n4 DATE,
+      n5 DATETIME
+    );
+    """)
+
+    %{db: db, conn: conn}
+  end
+
+  test "insert with auto inferred types", %{db: _, conn: conn} do
+    Adbc.Connection.query(
+      conn,
+      """
+      INSERT INTO test (i1, i2, i3, i4, i5, i6, i7, i8, i9, t1, t2, t3, t4, t5, t6, b1, r1, r2, r3, r4, n1, n2, n3, n4, n5)
+      VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      """,
+      [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        "hello",
+        "world",
+        "goodbye",
+        "world",
+        "foo",
+        "bar",
+        <<"data", 0x01, 0x02>>,
+        1.1,
+        2.2,
+        3.3,
+        4.4,
+        1.1,
+        2.2,
+        true,
+        "2021-01-01",
+        "2021-01-01 00:00:00"
+      ]
+    )
+
+    {:ok,
+     %Adbc.Result{
+       num_rows: nil,
+       data: %{
+         "b1" => [<<100, 97, 116, 97, 1, 2>>],
+         "i1" => [1],
+         "i2" => [2],
+         "i3" => [3],
+         "i4" => [4],
+         "i5" => [5],
+         "i6" => [6],
+         "i7" => ~c"\a",
+         "i8" => ~c"\b",
+         "i9" => ~c"\t",
+         "n1" => [1.1],
+         "n2" => [2.2],
+         "n3" => [1],
+         "n4" => ["2021-01-01"],
+         "n5" => ["2021-01-01 00:00:00"],
+         "r1" => [1.1],
+         "r2" => [2.2],
+         "r3" => [3.3],
+         "r4" => [4.4],
+         "t1" => ["hello"],
+         "t2" => ["world"],
+         "t3" => ["goodbye"],
+         "t4" => ["world"],
+         "t5" => ["foo"],
+         "t6" => ["bar"]
+       }
+     }} =
+      Adbc.Connection.query(conn, "SELECT * FROM test")
+  end
+
+  test "insert with Adbc.Buffer", %{db: _, conn: conn} do
+    Connection.query(
+      conn,
+      """
+      INSERT INTO test (i1, i2, i3, i4, i5, i6, i7, i8, i9, t1, t2, t3, t4, t5, t6, b1, r1, r2, r3, r4, n1, n2, n3, n4, n5)
+      VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      """,
+      [
+        Adbc.Buffer.i8([1]),
+        Adbc.Buffer.i16([2]),
+        Adbc.Buffer.i32([3]),
+        Adbc.Buffer.i64([4]),
+        Adbc.Buffer.u8([5]),
+        Adbc.Buffer.u16([6]),
+        Adbc.Buffer.u32([7]),
+        Adbc.Buffer.u64([8]),
+        Adbc.Buffer.u64([9]),
+        Adbc.Buffer.string(["hello"]),
+        Adbc.Buffer.string(["world"]),
+        Adbc.Buffer.string(["goodbye"]),
+        Adbc.Buffer.string(["world"]),
+        Adbc.Buffer.string(["foo"]),
+        Adbc.Buffer.string(["bar"]),
+        Adbc.Buffer.binary([<<"data", 0x01, 0x02>>]),
+        Adbc.Buffer.f32([1.1]),
+        Adbc.Buffer.f64([2.2]),
+        Adbc.Buffer.f32([3.3]),
+        Adbc.Buffer.f64([4.4]),
+        1.1,
+        2.2,
+        Adbc.Buffer.boolean([true]),
+        "2021-01-01",
+        "2021-01-01 00:00:00"
+      ]
+    )
+
+    {:ok,
+     %Adbc.Result{
+       num_rows: nil,
+       data: %{
+         "b1" => [<<100, 97, 116, 97, 1, 2>>],
+         "i1" => [1],
+         "i2" => [2],
+         "i3" => [3],
+         "i4" => [4],
+         "i5" => [5],
+         "i6" => [6],
+         "i7" => ~c"\a",
+         "i8" => ~c"\b",
+         "i9" => ~c"\t",
+         "n1" => [1.1],
+         "n2" => [2.2],
+         "n3" => [1],
+         "n4" => ["2021-01-01"],
+         "n5" => ["2021-01-01 00:00:00"],
+         "r1" => [r1],
+         "r2" => [2.2],
+         "r3" => [r3],
+         "r4" => [4.4],
+         "t1" => ["hello"],
+         "t2" => ["world"],
+         "t3" => ["goodbye"],
+         "t4" => ["world"],
+         "t5" => ["foo"],
+         "t6" => ["bar"]
+       }
+     }} = Connection.query(conn, "SELECT * FROM test")
+
+    assert is_float(r1) and is_float(r3)
+    assert abs(r1 - 1.1) < 1.0e-6
+    assert abs(r3 - 3.3) < 1.0e-6
+  end
+end


### PR DESCRIPTION
Hi @josevalim, this PR is currently a WIP and a draft for issue #66. 

If I understand your suggestions in #66 correctly, we're expecting users to do things like

```elixir
Adbc.Connection.query(conn, "INSERT INTO table(column_name) VALUES(?)", [Adbc.Buffer.i8([1])])
```

1. in `adbc_buffer_to_arrow_type_struct` (we can rename this later), we will iterate the parameter list, `[Adbc.Buffer.<type>...]`,
2. each of them corresponds to a field/column and will be parsed in `adbc_buffer_to_adbc_field`, and a corresponding `ArrowArray` and `ArrowSchema` will be built.
3. the parsed fields/columns will be assembled in `adbc_buffer_to_arrow_type_struct` and the result will be passed to `AdbcStatementBind`

Although I haven't quite decided how we should represent more complex data types like nested structs and lists using `Adbc.Buffer` yet.