### PR TITLE
Add support for decimal values

### DIFF
--- a/c_src/adbc_arrow_array.hpp
+++ b/c_src/adbc_arrow_array.hpp
@@ -483,6 +483,7 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
         return 1;
     }
 
+    char err_msg_buf[256] = { '\0' };
     const char* format = schema->format ? schema->format : "";
     const char* name = schema->name ? schema->name : "";
     term_type = kAtomNil;
@@ -847,9 +848,8 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
                 term_type = kAdbcColumnTypeDecimal(bits, precision, scale);
                 if (count == -1) count = values->length;
                 if (values->n_buffers != 2) {
-                    char buf[256] = { '\0' };
-                    snprintf(buf, 255, "invalid n_buffers value for ArrowArray (format=%s), values->n_buffers != 2", schema->format);
-                    error = erlang::nif::error(env, erlang::nif::make_binary(env, buf));
+                    snprintf(err_msg_buf, 255, "invalid n_buffers value for ArrowArray (format=%s), values->n_buffers != 2", schema->format);
+                    error = erlang::nif::error(env, erlang::nif::make_binary(env, err_msg_buf));
                     return 1;
                 }
                 current_term = fixed_size_binary_from_buffer(
@@ -1152,9 +1152,8 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
     }
 
     if (!format_processed) {
-        char buf[256] = { '\0' };
-        snprintf(buf, 255, "not yet implemented for format: `%s`", schema->format);
-        error = erlang::nif::error(env, erlang::nif::make_binary(env, buf));
+        snprintf(err_msg_buf, 255, "not yet implemented for format: `%s`", schema->format);
+        error = erlang::nif::error(env, erlang::nif::make_binary(env, err_msg_buf));
         return 1;
         // printf("not implemented for format: `%s`\r\n", schema->format);
         // printf("length: %lld\r\n", values->length);

--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -35,13 +35,17 @@ static ERL_NIF_TERM kAtomMinuteKey;
 static ERL_NIF_TERM kAtomSecondKey;
 static ERL_NIF_TERM kAtomMicrosecondKey;
 
+static ERL_NIF_TERM kAtomDecimalModule;
+static ERL_NIF_TERM kAtomCoefKey;
+static ERL_NIF_TERM kAtomExpKey;
+static ERL_NIF_TERM kAtomSignKey;
+
 static ERL_NIF_TERM kAtomAdbcColumnModule;
 static ERL_NIF_TERM kAtomNameKey;
 static ERL_NIF_TERM kAtomTypeKey;
 static ERL_NIF_TERM kAtomNullableKey;
 static ERL_NIF_TERM kAtomMetadataKey;
 static ERL_NIF_TERM kAtomDataKey;
-// static ERL_NIF_TERM kAtomPrivateKey;
 
 static ERL_NIF_TERM kAdbcColumnTypeU8;
 static ERL_NIF_TERM kAdbcColumnTypeU16;

--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -18,6 +18,7 @@ static ERL_NIF_TERM kAtomMilliseconds;
 static ERL_NIF_TERM kAtomMicroseconds;
 static ERL_NIF_TERM kAtomNanoseconds;
 static ERL_NIF_TERM kAtomTimestamp;
+static ERL_NIF_TERM kAtomDecimal;
 
 static ERL_NIF_TERM kAtomCalendarKey;
 static ERL_NIF_TERM kAtomCalendarISO;
@@ -77,6 +78,7 @@ static ERL_NIF_TERM kAdbcColumnTypeBool;
 #define kAdbcColumnTypeDurationMilliseconds enif_make_tuple2(env, kAtomDuration, kAtomMilliseconds)
 #define kAdbcColumnTypeDurationMicroseconds enif_make_tuple2(env, kAtomDuration, kAtomMicroseconds)
 #define kAdbcColumnTypeDurationNanoseconds enif_make_tuple2(env, kAtomDuration, kAtomNanoseconds)
+#define kAdbcColumnTypeDecimal(bitwidth, precision, scale) enif_make_tuple4(env, kAtomDecimal, enif_make_int(env, bitwidth), enif_make_int(env, precision), enif_make_int(env, scale))
 
 // error codes
 constexpr int kErrorBufferIsNotAMap = 1;

--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -35,11 +35,6 @@ static ERL_NIF_TERM kAtomMinuteKey;
 static ERL_NIF_TERM kAtomSecondKey;
 static ERL_NIF_TERM kAtomMicrosecondKey;
 
-static ERL_NIF_TERM kAtomDecimalModule;
-static ERL_NIF_TERM kAtomCoefKey;
-static ERL_NIF_TERM kAtomExpKey;
-static ERL_NIF_TERM kAtomSignKey;
-
 static ERL_NIF_TERM kAtomAdbcColumnModule;
 static ERL_NIF_TERM kAtomNameKey;
 static ERL_NIF_TERM kAtomTypeKey;

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -796,6 +796,7 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAtomMicroseconds = erlang::nif::atom(env, "microseconds");
     kAtomNanoseconds = erlang::nif::atom(env, "nanoseconds");
     kAtomTimestamp = erlang::nif::atom(env, "timestamp");
+    kAtomDecimal = erlang::nif::atom(env, "decimal");
 
     kAtomCalendarKey = erlang::nif::atom(env, "calendar");
     kAtomCalendarISO = erlang::nif::atom(env, "Elixir.Calendar.ISO");

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -813,11 +813,6 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAtomSecondKey = erlang::nif::atom(env, "second");
     kAtomMicrosecondKey = erlang::nif::atom(env, "microsecond");
 
-    kAtomDecimalModule = erlang::nif::atom(env, "Elixir.Decimal");
-    kAtomCoefKey = erlang::nif::atom(env, "coef");
-    kAtomExpKey = erlang::nif::atom(env, "exp");
-    kAtomSignKey = erlang::nif::atom(env, "sign");
-
     kAtomAdbcColumnModule = erlang::nif::atom(env, "Elixir.Adbc.Column");
     kAtomNameKey = erlang::nif::atom(env, "name");
     kAtomTypeKey = erlang::nif::atom(env, "type");

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -813,13 +813,17 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAtomSecondKey = erlang::nif::atom(env, "second");
     kAtomMicrosecondKey = erlang::nif::atom(env, "microsecond");
 
+    kAtomDecimalModule = erlang::nif::atom(env, "Elixir.Decimal");
+    kAtomCoefKey = erlang::nif::atom(env, "coef");
+    kAtomExpKey = erlang::nif::atom(env, "exp");
+    kAtomSignKey = erlang::nif::atom(env, "sign");
+
     kAtomAdbcColumnModule = erlang::nif::atom(env, "Elixir.Adbc.Column");
     kAtomNameKey = erlang::nif::atom(env, "name");
     kAtomTypeKey = erlang::nif::atom(env, "type");
     kAtomNullableKey = erlang::nif::atom(env, "nullable");
     kAtomMetadataKey = erlang::nif::atom(env, "metadata");
     kAtomDataKey = erlang::nif::atom(env, "data");
-    // kAdbcBufferPrivateKey = enif_make_atom(env, "__private__");
 
     kAdbcColumnTypeU8 = erlang::nif::atom(env, "u8");
     kAdbcColumnTypeU16 = erlang::nif::atom(env, "u16");

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -24,6 +24,11 @@ defmodule Adbc.Column do
   @type floating ::
           :f32
           | :f64
+  @type decimal128 :: {:decimal, 128, integer(), integer()}
+  @type decimal256 :: {:decimal, 256, integer(), integer()}
+  @type decimal_t ::
+          decimal128
+          | decimal256
   @type time_unit ::
           :seconds
           | :milliseconds
@@ -50,6 +55,7 @@ defmodule Adbc.Column do
           | signed_integer
           | unsigned_integer
           | floating
+          | decimal_t
           | :string
           | :large_string
           | :binary
@@ -441,6 +447,48 @@ defmodule Adbc.Column do
   @spec f64([float], Keyword.t()) :: %Adbc.Column{}
   def f64(data, opts \\ []) when is_list(data) and is_list(opts) do
     column(:f64, data, opts)
+  end
+
+  @doc """
+  A column that contains 128-bit decimals.
+
+  ## Arguments
+
+  * `data`: a list of `Decimal.t()`
+  * `precision`: The precision of the decimal values
+  * `scale`: The scale of the decimal values
+  * `opts`: A keyword list of options
+
+  ## Options
+
+  * `:name` - The name of the column
+  * `:nullable` - A boolean value indicating whether the column is nullable
+  * `:metadata` - A map of metadata
+  """
+  @spec decimal128([Decimal.t()], integer(), integer(), Keyword.t()) :: %Adbc.Column{}
+  def decimal128(data, precision, scale, opts \\ []) do
+    column({:decimal, 128, precision, scale}, data, opts)
+  end
+
+  @doc """
+  A column that contains 256-bit decimals.
+
+  ## Arguments
+
+  * `data`: a list of `Decimal.t()`
+  * `precision`: The precision of the decimal values
+  * `scale`: The scale of the decimal values
+  * `opts`: A keyword list of options
+
+  ## Options
+
+  * `:name` - The name of the column
+  * `:nullable` - A boolean value indicating whether the column is nullable
+  * `:metadata` - A map of metadata
+  """
+  @spec decimal256([Decimal.t()], integer(), integer(), Keyword.t()) :: %Adbc.Column{}
+  def decimal256(data, precision, scale, opts \\ []) do
+    column({:decimal, 256, precision, scale}, data, opts)
   end
 
   @doc """

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -407,13 +407,38 @@ defmodule Adbc.Connection do
     end
   end
 
-  defp merge_columns([result]), do: result
+  defp merge_columns([result]), do: handle_decimal(result)
 
   defp merge_columns(chucked_results) do
     Enum.zip_with(chucked_results, fn columns ->
       Enum.reduce(columns, fn column, merged_column ->
+        column = handle_decimal(column)
         %{merged_column | data: merged_column.data ++ column.data}
       end)
+    end)
+  end
+
+  defp handle_decimal([column | rest]) do
+    [handle_decimal(column) | handle_decimal(rest)]
+  end
+
+  defp handle_decimal(%Adbc.Column{type: {:decimal, bits, _, scale}, data: decimal_data} = column) do
+    %{column | data: handle_decimal(decimal_data, bits, scale)}
+  end
+
+  defp handle_decimal(column) do
+    column
+  end
+
+  defp handle_decimal(decimal_data, bits, scale) do
+    Enum.map(decimal_data, fn data ->
+      <<decimal::signed-integer-size(bits)-little>> = data
+
+      if decimal < 0 do
+        Decimal.new(-1, -decimal, -scale)
+      else
+        Decimal.new(1, decimal, -scale)
+      end
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -54,6 +54,7 @@ defmodule Adbc.MixProject do
       # runtime
       {:dll_loader_helper_beam, "~> 1.0"},
       {:castore, "~> 1.0", optional: true},
+      {:decimal, "~> 2.1"},
 
       # docs
       {:ex_doc, "~> 0.29", only: :docs, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
   "castore": {:hex, :castore, "1.0.6", "ffc42f110ebfdafab0ea159cd43d31365fa0af0ce4a02ecebf1707ae619ee727", [:mix], [], "hexpm", "374c6e7ca752296be3d6780a6d5b922854ffcc74123da90f2f328996b962d33a"},
   "cc_precompiler": {:hex, :cc_precompiler, "0.1.10", "47c9c08d8869cf09b41da36538f62bc1abd3e19e41701c2cea2675b53c704258", [:mix], [{:elixir_make, "~> 0.7", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "f6e046254e53cd6b41c6bacd70ae728011aa82b2742a80d6e2214855c6e06b22"},
+  "decimal": {:hex, :decimal, "2.1.1", "5611dca5d4b2c3dd497dec8f68751f1f1a54755e8ed2a966c2633cf885973ad6", [:mix], [], "hexpm", "53cfe5f497ed0e7771ae1a475575603d77425099ba5faef9394932b35020ffcc"},
   "dll_loader_helper_beam": {:hex, :dll_loader_helper_beam, "1.2.2", "b86f97ec8fc64770c87468e41969eb309d87b29dd5a439b667e5954f85f8f65a", [:rebar3], [], "hexpm", "0e6119edde0ef5e42b4fe22d7dc71b7462e08573cee977c01a26ec5d9cd94a9a"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.39", "424642f8335b05bb9eb611aa1564c148a8ee35c9c8a8bba6e129d51a3e3c6769", [:mix], [], "hexpm", "06553a88d1f1846da9ef066b87b57c6f605552cfbe40d20bd8d59cc6bde41944"},
   "elixir_make": {:hex, :elixir_make, "0.8.3", "d38d7ee1578d722d89b4d452a3e36bcfdc644c618f0d063b874661876e708683", [:mix], [{:castore, "~> 0.1 or ~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:certifi, "~> 2.0", [hex: :certifi, repo: "hexpm", optional: true]}], "hexpm", "5c99a18571a756d4af7a4d89ca75c28ac899e6103af6f223982f09ce44942cc9"},

--- a/test/adbc_column_test.exs
+++ b/test/adbc_column_test.exs
@@ -1,0 +1,226 @@
+defmodule Adbc.Column.Test do
+  use ExUnit.Case
+
+  describe "decimals" do
+    test "integers" do
+      value = 42
+      bitwidth = 128
+      precision = 19
+      scale = 10
+      decimal = Decimal.new(value)
+
+      assert %Adbc.Column{
+               data: [data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal128([decimal], precision, scale)
+
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert value == decode / :math.pow(10, scale)
+
+      bitwidth = 256
+
+      assert %Adbc.Column{
+               data: [data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal256([decimal], precision, scale)
+
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert value == decode / :math.pow(10, scale)
+    end
+
+    test "floats" do
+      value = 12345
+
+      bitwidth = 128
+      precision = 5
+      scale = 10
+
+      exp = -3
+      actual_value = value * :math.pow(10, exp)
+      decimal = Decimal.new(1, value, exp)
+
+      assert %Adbc.Column{
+               data: [data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal128([decimal], precision, scale)
+
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert actual_value == decode / :math.pow(10, scale)
+
+      bitwidth = 256
+
+      assert %Adbc.Column{
+               data: [data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal256([decimal], precision, scale)
+
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert actual_value == decode / :math.pow(10, scale)
+    end
+
+    test "raise if precision value is insufficient" do
+      value = 54321
+      bitwidth = 128
+      precision = 4
+      scale = 1
+      decimal = Decimal.new(value)
+
+      assert_raise Adbc.Error,
+                   "`54321` cannot be fitted into a decimal128 with the specified precision 4",
+                   fn ->
+                     Adbc.Column.decimal128([decimal], precision, scale)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`54321` cannot be fitted into a decimal256 with the specified precision 4",
+                   fn ->
+                     Adbc.Column.decimal256([decimal], precision, scale)
+                   end
+
+      precision = 5
+
+      assert %Adbc.Column{
+               data: [data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal128([decimal], precision, scale)
+
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert value == decode / :math.pow(10, scale)
+
+      bitwidth = 256
+
+      assert %Adbc.Column{
+               data: [data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal256([decimal], precision, scale)
+
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert value == decode / :math.pow(10, scale)
+    end
+
+    test "raise if scale value is insufficient" do
+      value = 54321
+      bitwidth = 128
+      precision = 5
+      scale = 1
+
+      exp = -2
+      actual_value = value * :math.pow(10, exp)
+      decimal = Decimal.new(1, value, exp)
+
+      assert_raise Adbc.Error,
+                   "`543.21` with exponent `-2` cannot be represented as a valid decimal128 number with scale value `1`",
+                   fn ->
+                     Adbc.Column.decimal128([decimal], precision, scale)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`543.21` with exponent `-2` cannot be represented as a valid decimal256 number with scale value `1`",
+                   fn ->
+                     Adbc.Column.decimal256([decimal], precision, scale)
+                   end
+
+      scale = 2
+
+      assert %Adbc.Column{
+               data: [data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal128([decimal], precision, scale)
+
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert actual_value == decode / :math.pow(10, scale)
+
+      bitwidth = 256
+
+      assert %Adbc.Column{
+               data: [data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal256([decimal], precision, scale)
+
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert actual_value == decode / :math.pow(10, scale)
+    end
+
+    test "raise on Inf, -Inf and NaN" do
+      assert_raise Adbc.Error,
+                   "`Infinity` cannot be represented as a valid decimal128 number",
+                   fn ->
+                     Adbc.Column.decimal128([Decimal.new("inf")], 19, 10)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`Infinity` cannot be represented as a valid decimal128 number",
+                   fn ->
+                     Adbc.Column.decimal128([Decimal.new("1"), Decimal.new("inf")], 19, 10)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`-Infinity` cannot be represented as a valid decimal128 number",
+                   fn ->
+                     Adbc.Column.decimal128([Decimal.new("-inf")], 19, 10)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`-Infinity` cannot be represented as a valid decimal128 number",
+                   fn ->
+                     Adbc.Column.decimal128([Decimal.new("1"), Decimal.new("-inf")], 19, 10)
+                   end
+
+      assert_raise Adbc.Error, "`NaN` cannot be represented as a valid decimal128 number", fn ->
+        Adbc.Column.decimal128([Decimal.new("NaN")], 19, 10)
+      end
+
+      assert_raise Adbc.Error,
+                   "`Infinity` cannot be represented as a valid decimal256 number",
+                   fn ->
+                     Adbc.Column.decimal256([Decimal.new("inf")], 19, 10)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`Infinity` cannot be represented as a valid decimal256 number",
+                   fn ->
+                     Adbc.Column.decimal256([Decimal.new("1"), Decimal.new("inf")], 19, 10)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`-Infinity` cannot be represented as a valid decimal256 number",
+                   fn ->
+                     Adbc.Column.decimal256([Decimal.new("-inf")], 19, 10)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`-Infinity` cannot be represented as a valid decimal256 number",
+                   fn ->
+                     Adbc.Column.decimal256([Decimal.new("1"), Decimal.new("-inf")], 19, 10)
+                   end
+
+      assert_raise Adbc.Error, "`NaN` cannot be represented as a valid decimal256 number", fn ->
+        Adbc.Column.decimal256([Decimal.new("NaN")], 19, 10)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This draft PR adds support for decoding decimal values from Arrow streams. 

But I'm kinda confused about the encoding part -- how to translate an arbitrary `Decimal.t()` to an `ArrowDecimal` with the given precision and scale... 

I was wondering if you by any chance have any hints or suggestions @josevalim?