### PR TITLE
allow numbers in `Adbc.Column.decimal{128,256}`

### DIFF
--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -456,7 +456,7 @@ defmodule Adbc.Column do
 
   * `data`: a list, each element can be either
     * a `Decimal.t()`
-    * a `number()`
+    * an `integer()`
   * `precision`: The precision of the decimal values
   * `scale`: The scale of the decimal values
   * `opts`: A keyword list of options
@@ -467,7 +467,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
-  @spec decimal128([Decimal.t() | number()], integer(), integer(), Keyword.t()) :: %Adbc.Column{}
+  @spec decimal128([Decimal.t() | integer()], integer(), integer(), Keyword.t()) :: %Adbc.Column{}
   def decimal128(data, precision, scale, opts \\ [])
       when is_integer(precision) and precision >= 1 and precision <= 38 do
     bitwidth = 128
@@ -486,7 +486,7 @@ defmodule Adbc.Column do
 
   * `data`: a list, each element can be either
     * a `Decimal.t()`
-    * a `number()`
+    * an `integer()`
   * `precision`: The precision of the decimal values
   * `scale`: The scale of the decimal values
   * `opts`: A keyword list of options
@@ -497,7 +497,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
-  @spec decimal256([Decimal.t() | number()], integer(), integer(), Keyword.t()) :: %Adbc.Column{}
+  @spec decimal256([Decimal.t() | integer()], integer(), integer(), Keyword.t()) :: %Adbc.Column{}
   def decimal256(data, precision, scale, opts \\ [])
       when is_integer(precision) and precision >= 1 and precision <= 38 do
     bitwidth = 256
@@ -524,28 +524,6 @@ defmodule Adbc.Column do
       coef = trunc(integer * :math.pow(10, scale))
       acc = [<<coef::signed-integer-little-size(bitwidth)>> | acc]
       preprocess_decimal(bitwidth, precision, scale, rest, acc)
-    end
-  end
-
-  defp preprocess_decimal(bitwidth, precision, scale, [float | rest], acc) when is_float(float) do
-    float_string = Float.to_string(float)
-    [i, f] = String.split(float_string, ".")
-    min_scale = String.length(String.trim_trailing(f, "0"))
-
-    if min_scale > scale do
-      raise Adbc.Error,
-            "Rescaling `#{float_string}` as a valid decimal#{Integer.to_string(bitwidth)} number would cause data loss with scale value `#{scale}`"
-    else
-      min_precision = String.length(i) + min_scale
-
-      if min_precision > precision do
-        raise Adbc.Error,
-              "Rescaling `#{float_string}` as a valid decimal#{Integer.to_string(bitwidth)} number would cause data loss with precision #{Integer.to_string(precision)}"
-      else
-        scaled = trunc(float * :math.pow(10, scale))
-        acc = [<<scaled::signed-integer-little-size(bitwidth)>> | acc]
-        preprocess_decimal(bitwidth, precision, scale, rest, acc)
-      end
     end
   end
 

--- a/test/adbc_column_test.exs
+++ b/test/adbc_column_test.exs
@@ -52,34 +52,28 @@ defmodule Adbc.Column.Test do
       decimal = Decimal.new(1, value, exp)
 
       assert %Adbc.Column{
-               data: [decimal_data, value_data],
+               data: [data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal128([decimal, actual_value], precision, scale)
+             } = Adbc.Column.decimal128([decimal], precision, scale)
 
-      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
-      assert actual_value == decode1 / :math.pow(10, scale)
-
-      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
-      assert actual_value == decode2 / :math.pow(10, scale)
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert actual_value == decode / :math.pow(10, scale)
 
       bitwidth = 256
 
       assert %Adbc.Column{
-               data: [decimal_data, value_data],
+               data: [data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal256([decimal, actual_value], precision, scale)
+             } = Adbc.Column.decimal256([decimal], precision, scale)
 
-      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
-      assert actual_value == decode1 / :math.pow(10, scale)
-
-      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
-      assert actual_value == decode2 / :math.pow(10, scale)
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert actual_value == decode / :math.pow(10, scale)
     end
 
     test "raise if precision value is insufficient" do
@@ -163,121 +157,36 @@ defmodule Adbc.Column.Test do
                    end
 
       assert_raise Adbc.Error,
-                   "Rescaling `543.21` as a valid decimal128 number would cause data loss with scale value `1`",
-                   fn ->
-                     Adbc.Column.decimal128([actual_value], precision, scale)
-                   end
-
-      assert_raise Adbc.Error,
                    "`543.21` with exponent `-2` cannot be represented as a valid decimal256 number with scale value `1`",
                    fn ->
                      Adbc.Column.decimal256([decimal], precision, scale)
                    end
 
-      assert_raise Adbc.Error,
-                   "Rescaling `543.21` as a valid decimal256 number would cause data loss with scale value `1`",
-                   fn ->
-                     Adbc.Column.decimal256([actual_value], precision, scale)
-                   end
-
       scale = 2
 
       assert %Adbc.Column{
-               data: [decimal_data, value_data],
+               data: [data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal128([decimal, actual_value], precision, scale)
+             } = Adbc.Column.decimal128([decimal], precision, scale)
 
-      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
-      assert actual_value == decode1 / :math.pow(10, scale)
-
-      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
-      assert actual_value == decode2 / :math.pow(10, scale)
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert actual_value == decode / :math.pow(10, scale)
 
       bitwidth = 256
 
       assert %Adbc.Column{
-               data: [decimal_data, value_data],
+               data: [data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal256([decimal, actual_value], precision, scale)
+             } = Adbc.Column.decimal256([decimal], precision, scale)
 
-      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
-      assert actual_value == decode1 / :math.pow(10, scale)
-
-      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
-      assert actual_value == decode2 / :math.pow(10, scale)
-    end
-
-    test "raise if precision value is insufficient after rescaling" do
-      value = 54321
-      bitwidth = 128
-      precision = 4
-      scale = 2
-
-      exp = -2
-      actual_value = value * :math.pow(10, exp)
-      decimal = Decimal.new(1, value, exp)
-
-      assert_raise Adbc.Error,
-                   "`543.21` cannot be fitted into a decimal128 with the specified precision 4",
-                   fn ->
-                     Adbc.Column.decimal128([decimal], precision, scale)
-                   end
-
-      assert_raise Adbc.Error,
-                   "Rescaling `543.21` as a valid decimal128 number would cause data loss with precision 4",
-                   fn ->
-                     Adbc.Column.decimal128([actual_value], precision, scale)
-                   end
-
-      assert_raise Adbc.Error,
-                   "`543.21` cannot be fitted into a decimal256 with the specified precision 4",
-                   fn ->
-                     Adbc.Column.decimal256([decimal], precision, scale)
-                   end
-
-      assert_raise Adbc.Error,
-                   "Rescaling `543.21` as a valid decimal256 number would cause data loss with precision 4",
-                   fn ->
-                     Adbc.Column.decimal256([actual_value], precision, scale)
-                   end
-
-      precision = 5
-
-      assert %Adbc.Column{
-               data: [decimal_data, value_data],
-               metadata: nil,
-               name: nil,
-               nullable: false,
-               type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal128([decimal, actual_value], precision, scale)
-
-      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
-      assert actual_value == decode1 / :math.pow(10, scale)
-
-      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
-      assert actual_value == decode2 / :math.pow(10, scale)
-
-      bitwidth = 256
-
-      assert %Adbc.Column{
-               data: [decimal_data, value_data],
-               metadata: nil,
-               name: nil,
-               nullable: false,
-               type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal256([decimal, actual_value], precision, scale)
-
-      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
-      assert actual_value == decode1 / :math.pow(10, scale)
-
-      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
-      assert actual_value == decode2 / :math.pow(10, scale)
+      assert <<decode::signed-integer-little-size(bitwidth)>> = data
+      assert actual_value == decode / :math.pow(10, scale)
     end
 
     test "raise on Inf, -Inf and NaN" do

--- a/test/adbc_column_test.exs
+++ b/test/adbc_column_test.exs
@@ -10,28 +10,34 @@ defmodule Adbc.Column.Test do
       decimal = Decimal.new(value)
 
       assert %Adbc.Column{
-               data: [data],
+               data: [decimal_data, value_data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal128([decimal], precision, scale)
+             } = Adbc.Column.decimal128([decimal, value], precision, scale)
 
-      assert <<decode::signed-integer-little-size(bitwidth)>> = data
-      assert value == decode / :math.pow(10, scale)
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert value == decode2 / :math.pow(10, scale)
 
       bitwidth = 256
 
       assert %Adbc.Column{
-               data: [data],
+               data: [decimal_data, value_data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal256([decimal], precision, scale)
+             } = Adbc.Column.decimal256([decimal, value], precision, scale)
 
-      assert <<decode::signed-integer-little-size(bitwidth)>> = data
-      assert value == decode / :math.pow(10, scale)
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert value == decode2 / :math.pow(10, scale)
     end
 
     test "floats" do
@@ -46,28 +52,34 @@ defmodule Adbc.Column.Test do
       decimal = Decimal.new(1, value, exp)
 
       assert %Adbc.Column{
-               data: [data],
+               data: [decimal_data, value_data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal128([decimal], precision, scale)
+             } = Adbc.Column.decimal128([decimal, actual_value], precision, scale)
 
-      assert <<decode::signed-integer-little-size(bitwidth)>> = data
-      assert actual_value == decode / :math.pow(10, scale)
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert actual_value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert actual_value == decode2 / :math.pow(10, scale)
 
       bitwidth = 256
 
       assert %Adbc.Column{
-               data: [data],
+               data: [decimal_data, value_data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal256([decimal], precision, scale)
+             } = Adbc.Column.decimal256([decimal, actual_value], precision, scale)
 
-      assert <<decode::signed-integer-little-size(bitwidth)>> = data
-      assert actual_value == decode / :math.pow(10, scale)
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert actual_value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert actual_value == decode2 / :math.pow(10, scale)
     end
 
     test "raise if precision value is insufficient" do
@@ -84,36 +96,54 @@ defmodule Adbc.Column.Test do
                    end
 
       assert_raise Adbc.Error,
+                   "`54321` cannot be fitted into a decimal128 with the specified precision 4",
+                   fn ->
+                     Adbc.Column.decimal128([value], precision, scale)
+                   end
+
+      assert_raise Adbc.Error,
                    "`54321` cannot be fitted into a decimal256 with the specified precision 4",
                    fn ->
                      Adbc.Column.decimal256([decimal], precision, scale)
                    end
 
+      assert_raise Adbc.Error,
+                   "`54321` cannot be fitted into a decimal256 with the specified precision 4",
+                   fn ->
+                     Adbc.Column.decimal256([value], precision, scale)
+                   end
+
       precision = 5
 
       assert %Adbc.Column{
-               data: [data],
+               data: [decimal_data, value_data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal128([decimal], precision, scale)
+             } = Adbc.Column.decimal128([decimal, value], precision, scale)
 
-      assert <<decode::signed-integer-little-size(bitwidth)>> = data
-      assert value == decode / :math.pow(10, scale)
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert value == decode2 / :math.pow(10, scale)
 
       bitwidth = 256
 
       assert %Adbc.Column{
-               data: [data],
+               data: [decimal_data, value_data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal256([decimal], precision, scale)
+             } = Adbc.Column.decimal256([decimal, value], precision, scale)
 
-      assert <<decode::signed-integer-little-size(bitwidth)>> = data
-      assert value == decode / :math.pow(10, scale)
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert value == decode2 / :math.pow(10, scale)
     end
 
     test "raise if scale value is insufficient" do
@@ -133,36 +163,121 @@ defmodule Adbc.Column.Test do
                    end
 
       assert_raise Adbc.Error,
+                   "Rescaling `543.21` as a valid decimal128 number would cause data loss with scale value `1`",
+                   fn ->
+                     Adbc.Column.decimal128([actual_value], precision, scale)
+                   end
+
+      assert_raise Adbc.Error,
                    "`543.21` with exponent `-2` cannot be represented as a valid decimal256 number with scale value `1`",
                    fn ->
                      Adbc.Column.decimal256([decimal], precision, scale)
                    end
 
+      assert_raise Adbc.Error,
+                   "Rescaling `543.21` as a valid decimal256 number would cause data loss with scale value `1`",
+                   fn ->
+                     Adbc.Column.decimal256([actual_value], precision, scale)
+                   end
+
       scale = 2
 
       assert %Adbc.Column{
-               data: [data],
+               data: [decimal_data, value_data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal128([decimal], precision, scale)
+             } = Adbc.Column.decimal128([decimal, actual_value], precision, scale)
 
-      assert <<decode::signed-integer-little-size(bitwidth)>> = data
-      assert actual_value == decode / :math.pow(10, scale)
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert actual_value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert actual_value == decode2 / :math.pow(10, scale)
 
       bitwidth = 256
 
       assert %Adbc.Column{
-               data: [data],
+               data: [decimal_data, value_data],
                metadata: nil,
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
-             } = Adbc.Column.decimal256([decimal], precision, scale)
+             } = Adbc.Column.decimal256([decimal, actual_value], precision, scale)
 
-      assert <<decode::signed-integer-little-size(bitwidth)>> = data
-      assert actual_value == decode / :math.pow(10, scale)
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert actual_value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert actual_value == decode2 / :math.pow(10, scale)
+    end
+
+    test "raise if precision value is insufficient after rescaling" do
+      value = 54321
+      bitwidth = 128
+      precision = 4
+      scale = 2
+
+      exp = -2
+      actual_value = value * :math.pow(10, exp)
+      decimal = Decimal.new(1, value, exp)
+
+      assert_raise Adbc.Error,
+                   "`543.21` cannot be fitted into a decimal128 with the specified precision 4",
+                   fn ->
+                     Adbc.Column.decimal128([decimal], precision, scale)
+                   end
+
+      assert_raise Adbc.Error,
+                   "Rescaling `543.21` as a valid decimal128 number would cause data loss with precision 4",
+                   fn ->
+                     Adbc.Column.decimal128([actual_value], precision, scale)
+                   end
+
+      assert_raise Adbc.Error,
+                   "`543.21` cannot be fitted into a decimal256 with the specified precision 4",
+                   fn ->
+                     Adbc.Column.decimal256([decimal], precision, scale)
+                   end
+
+      assert_raise Adbc.Error,
+                   "Rescaling `543.21` as a valid decimal256 number would cause data loss with precision 4",
+                   fn ->
+                     Adbc.Column.decimal256([actual_value], precision, scale)
+                   end
+
+      precision = 5
+
+      assert %Adbc.Column{
+               data: [decimal_data, value_data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal128([decimal, actual_value], precision, scale)
+
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert actual_value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert actual_value == decode2 / :math.pow(10, scale)
+
+      bitwidth = 256
+
+      assert %Adbc.Column{
+               data: [decimal_data, value_data],
+               metadata: nil,
+               name: nil,
+               nullable: false,
+               type: {:decimal, ^bitwidth, ^precision, ^scale}
+             } = Adbc.Column.decimal256([decimal, actual_value], precision, scale)
+
+      assert <<decode1::signed-integer-little-size(bitwidth)>> = decimal_data
+      assert actual_value == decode1 / :math.pow(10, scale)
+
+      assert <<decode2::signed-integer-little-size(bitwidth)>> = value_data
+      assert actual_value == decode2 / :math.pow(10, scale)
     end
 
     test "raise on Inf, -Inf and NaN" do


### PR DESCRIPTION
Accepts `number()` for `Adbc.Column.decimal{128,256}`. Related PR #79