### PR TITLE
fixed `Adbc.Column.fixed_size_binary/3`

### DIFF
--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -17,8 +17,9 @@ static ERL_NIF_TERM kAtomSeconds;
 static ERL_NIF_TERM kAtomMilliseconds;
 static ERL_NIF_TERM kAtomMicroseconds;
 static ERL_NIF_TERM kAtomNanoseconds;
-static ERL_NIF_TERM kAtomTimestamp;
 static ERL_NIF_TERM kAtomDecimal;
+static ERL_NIF_TERM kAtomTimestamp;
+static ERL_NIF_TERM kAtomFixedSizeBinary;
 
 static ERL_NIF_TERM kAtomCalendarKey;
 static ERL_NIF_TERM kAtomCalendarISO;
@@ -61,7 +62,6 @@ static ERL_NIF_TERM kAdbcColumnTypeString;
 static ERL_NIF_TERM kAdbcColumnTypeLargeString;
 static ERL_NIF_TERM kAdbcColumnTypeBinary;
 static ERL_NIF_TERM kAdbcColumnTypeLargeBinary;
-static ERL_NIF_TERM kAdbcColumnTypeFixedSizeBinary;
 static ERL_NIF_TERM kAdbcColumnTypeDenseUnion;
 static ERL_NIF_TERM kAdbcColumnTypeSparseUnion;
 static ERL_NIF_TERM kAdbcColumnTypeDate32;
@@ -78,6 +78,7 @@ static ERL_NIF_TERM kAdbcColumnTypeBool;
 #define kAdbcColumnTypeDurationMicroseconds enif_make_tuple2(env, kAtomDuration, kAtomMicroseconds)
 #define kAdbcColumnTypeDurationNanoseconds enif_make_tuple2(env, kAtomDuration, kAtomNanoseconds)
 #define kAdbcColumnTypeDecimal(bitwidth, precision, scale) enif_make_tuple4(env, kAtomDecimal, enif_make_int(env, bitwidth), enif_make_int(env, precision), enif_make_int(env, scale))
+#define kAdbcColumnTypeFixedSizeBinary(nbytes) enif_make_tuple2(env, kAtomFixedSizeBinary, enif_make_int64(env, nbytes))
 
 // error codes
 constexpr int kErrorBufferIsNotAMap = 1;

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -797,6 +797,7 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAtomNanoseconds = erlang::nif::atom(env, "nanoseconds");
     kAtomTimestamp = erlang::nif::atom(env, "timestamp");
     kAtomDecimal = erlang::nif::atom(env, "decimal");
+    kAtomFixedSizeBinary = erlang::nif::atom(env, "fixed_size_binary");
 
     kAtomCalendarKey = erlang::nif::atom(env, "calendar");
     kAtomCalendarISO = erlang::nif::atom(env, "Elixir.Calendar.ISO");
@@ -839,7 +840,6 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAdbcColumnTypeLargeString = erlang::nif::atom(env, "large_string");
     kAdbcColumnTypeBinary = erlang::nif::atom(env, "binary");
     kAdbcColumnTypeLargeBinary = erlang::nif::atom(env, "large_binary");
-    kAdbcColumnTypeFixedSizeBinary = erlang::nif::atom(env, "fixed_size_binary");
     kAdbcColumnTypeDenseUnion = erlang::nif::atom(env, "dense_union");
     kAdbcColumnTypeSparseUnion = erlang::nif::atom(env, "sparse_union");
     kAdbcColumnTypeDate32 = erlang::nif::atom(env, "date32");

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -60,7 +60,7 @@ defmodule Adbc.Column do
           | :large_string
           | :binary
           | :large_binary
-          | :fixed_size_binary
+          | {:fixed_size_binary, non_neg_integer()}
           | :date32
           | :date64
           | time32_t
@@ -674,6 +674,7 @@ defmodule Adbc.Column do
   ## Arguments
 
   * `data`: A list of binary values
+  * `nbytes`: The fixed size of the binary values in bytes
   * `opts`: A keyword list of options
 
   ## Options
@@ -684,19 +685,19 @@ defmodule Adbc.Column do
 
   ## Examples
 
-      iex> Adbc.Buffer.fixed_size_binary([<<0>>, <<1>>, <<2>>])
+      iex> Adbc.Buffer.fixed_size_binary([<<0>>, <<1>>, <<2>>], 1)
       %Adbc.Column{
         name: nil,
-        type: :fixed_size_binary,
+        type: {:fixed_size_binary, 1},
         nullable: false,
         metadata: %{},
         data: [<<0>>, <<1>>, <<2>>]
       }
 
   """
-  @spec fixed_size_binary([binary()], Keyword.t()) :: %Adbc.Column{}
-  def fixed_size_binary(data, opts \\ []) when is_list(data) and is_list(opts) do
-    column(:fixed_size_binary, data, opts)
+  @spec fixed_size_binary([binary() | nil], non_neg_integer(), Keyword.t()) :: %Adbc.Column{}
+  def fixed_size_binary(data, nbytes, opts \\ []) when is_list(data) and is_list(opts) do
+    column({:fixed_size_binary, nbytes}, data, opts)
   end
 
   @doc """


### PR DESCRIPTION
This PR fixed how fixed-sized binary is handled from and to an arrow array.