### PR TITLE
feat: implemented list types for `Adbc.Column`

### DIFF
--- a/c_src/adbc_arrow_array.hpp
+++ b/c_src/adbc_arrow_array.hpp
@@ -16,8 +16,8 @@ static int get_arrow_array_children_as_list(ErlNifEnv *env, struct ArrowSchema *
 static int get_arrow_array_children_as_list(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, int64_t offset, int64_t count, uint64_t level, std::vector<ERL_NIF_TERM> &children, ERL_NIF_TERM &error);
 static ERL_NIF_TERM get_arrow_array_map_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, uint64_t level);
 static ERL_NIF_TERM get_arrow_array_map_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, int64_t offset, int64_t count, uint64_t level);
-static ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, uint64_t level);
-static ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, int64_t offset, int64_t count, uint64_t level);
+static ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, uint64_t level, ArrowType list_type, unsigned n_items = 0);
+static ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, int64_t offset, int64_t count, uint64_t level, ArrowType list_type, unsigned n_items = 0);
 static ERL_NIF_TERM get_arrow_array_dense_union_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, uint64_t level);
 static ERL_NIF_TERM get_arrow_array_dense_union_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, int64_t offset, int64_t count, uint64_t level);
 static ERL_NIF_TERM get_arrow_array_sparse_union_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, uint64_t level);
@@ -391,7 +391,7 @@ ERL_NIF_TERM get_arrow_array_sparse_union_children(ErlNifEnv *env, struct ArrowS
     return get_arrow_array_sparse_union_children(env, schema, values, 0, -1, level);
 }
 
-ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, int64_t offset, int64_t count, uint64_t level) {
+ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, int64_t offset, int64_t count, uint64_t level, ArrowType list_type, unsigned n_items) {
     ERL_NIF_TERM error{};
     if (schema->children == nullptr) {
         return erlang::nif::error(env, "invalid ArrowSchema (list), schema->children == nullptr");
@@ -404,6 +404,9 @@ ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * 
     }
     if (values->n_children != 1) {
         return erlang::nif::error(env, "invalid ArrowArray (list), values->n_children != 1");
+    }
+    if (list_type != NANOARROW_TYPE_LIST && list_type != NANOARROW_TYPE_LARGE_LIST && list_type != NANOARROW_TYPE_FIXED_SIZE_LIST) {
+        return erlang::nif::error(env, "invalid ArrowArray (list), internal error: unexpected list type");
     }
 
     constexpr int64_t bitmap_buffer_index = 0;
@@ -456,28 +459,71 @@ ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * 
         }
         return enif_make_list_from_array(env, children.data(), (unsigned)children.size());
     } else {
-        constexpr int64_t offset_buffer_index = 1;
-        const int32_t * offsets = (const int32_t *)values->buffers[offset_buffer_index];
-        if (offsets == nullptr) {
-            return erlang::nif::error(env, "invalid ArrowArray (list), offsets == nullptr");
-        }
-        if (count == -1) count = values->length;
-        for (int64_t i = offset; i < offset + count; i++) {
-            std::vector<ERL_NIF_TERM> childrens;
-            ERL_NIF_TERM children_type;
-            ERL_NIF_TERM children_metadata;
-            if (arrow_array_to_nif_term(env, items_schema, items_values, offsets[i], offsets[i+1] - offsets[i], level + 1, childrens, children_type, children_metadata, error) == 1) {
-                return error;
-            }
+        if (list_type == NANOARROW_TYPE_LIST || list_type == NANOARROW_TYPE_LARGE_LIST) {
+            constexpr int64_t offset_buffer_index = 1;
+            const void * offsets_ptr = (const void *)values->buffers[offset_buffer_index];
+            if (offsets_ptr == nullptr) return erlang::nif::error(env, "invalid ArrowArray (list), offsets == nullptr");
+            if (count == -1) count = values->length;
 
-            if (childrens.size() == 1) {
-                children.emplace_back(childrens[0]);
-            } else {
-                bool children_nullable = (schema->flags & ARROW_FLAG_NULLABLE) || (values->null_count > 0);
-                if (enif_is_identical(childrens[1], kAtomNil)) {
-                    children.emplace_back(kAtomNil);
+            int has_error = 0;
+            auto get_list_children_with_offsets = [&](auto offsets) -> void {
+                for (int64_t i = offset; i < offset + count; i++) {
+                    std::vector<ERL_NIF_TERM> childrens;
+                    ERL_NIF_TERM children_type;
+                    ERL_NIF_TERM children_metadata;
+                    if (arrow_array_to_nif_term(env, items_schema, items_values, offsets[i], offsets[i+1] - offsets[i], level + 1, childrens, children_type, children_metadata, error) == 1) {
+                        has_error = 1;
+                        return;
+                    }
+
+                    if (childrens.size() == 1) {
+                        children.emplace_back(childrens[0]);
+                    } else {
+                        bool children_nullable = (schema->flags & ARROW_FLAG_NULLABLE) || (values->null_count > 0);
+                        if (enif_is_identical(childrens[1], kAtomNil)) {
+                            children.emplace_back(kAtomNil);
+                        } else {
+                            children.emplace_back(make_adbc_column(env, childrens[0], children_type, children_nullable, children_metadata, childrens[1]));
+                        }
+                    }
+                }
+            };
+
+            if (list_type == NANOARROW_TYPE_LIST) {
+                get_list_children_with_offsets((const int32_t *)offsets_ptr);
+                if (has_error) return error;
+            } else if (list_type == NANOARROW_TYPE_LARGE_LIST) {
+                get_list_children_with_offsets((const int64_t *)offsets_ptr);
+                if (has_error) return error;
+            }
+        } else {
+            // NANOARROW_TYPE_FIXED_SIZE_LIST
+            if (count == -1) count = values->length;
+            bool items_nullable = (items_schema->flags & ARROW_FLAG_NULLABLE) || (items_values->null_count > 0);
+            for (int64_t child_i = offset; child_i < offset + count; child_i++) {
+                if (bitmap_buffer && items_nullable) {
+                    uint8_t vbyte = bitmap_buffer[child_i / 8];
+                    if (!(vbyte & (1 << (child_i % 8)))) {
+                        children.emplace_back(kAtomNil);
+                        continue;
+                    }
+                }
+
+                std::vector<ERL_NIF_TERM> childrens;
+                ERL_NIF_TERM children_type;
+                ERL_NIF_TERM children_metadata;
+                if (arrow_array_to_nif_term(env, items_schema, items_values, child_i * n_items, n_items, level + 1, childrens, children_type, children_metadata, error)) {
+                    return error;
+                }
+                if (childrens.size() == 1) {
+                    children.emplace_back(childrens[0]);
                 } else {
-                    children.emplace_back(make_adbc_column(env, childrens[0], children_type, children_nullable, children_metadata, childrens[1]));
+                    bool children_nullable = (schema->flags & ARROW_FLAG_NULLABLE) || (values->null_count > 0);
+                    if (enif_is_identical(childrens[1], kAtomNil)) {
+                        children.emplace_back(kAtomNil);
+                    } else {
+                        children.emplace_back(make_adbc_column(env, childrens[0], children_type, children_nullable, children_metadata, childrens[1]));
+                    }
                 }
             }
         }
@@ -485,8 +531,8 @@ ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * 
     }
 }
 
-ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, uint64_t level) {
-    return get_arrow_array_list_children(env, schema, values, 0, -1, level);
+ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, uint64_t level, ArrowType list_type, unsigned n_items) {
+    return get_arrow_array_list_children(env, schema, values, 0, -1, level, list_type, n_items);
 }
 
 int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct ArrowArray * values, int64_t offset, int64_t count, int64_t level, std::vector<ERL_NIF_TERM> &out_terms, ERL_NIF_TERM &term_type, ERL_NIF_TERM &arrow_metadata, ERL_NIF_TERM &error, bool *end_of_series) {
@@ -868,19 +914,23 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
         } else if (strncmp("+l", format, 2) == 0) {
             // NANOARROW_TYPE_LIST
             term_type = kAdbcColumnTypeList;
-            children_term = get_arrow_array_list_children(env, schema, values, offset, count, level);
+            children_term = get_arrow_array_list_children(env, schema, values, offset, count, level, NANOARROW_TYPE_LIST);
         } else if (strncmp("+L", format, 2) == 0) {
             // NANOARROW_TYPE_LARGE_LIST
             term_type = kAdbcColumnTypeLargeList;
-            children_term = get_arrow_array_list_children(env, schema, values, offset, count, level);
+            children_term = get_arrow_array_list_children(env, schema, values, offset, count, level, NANOARROW_TYPE_LARGE_LIST);
         } else {
             format_processed = false;
         }
     } else if (format_len >= 3) {
         if (strncmp("+w:", format, 3) == 0) {
             // NANOARROW_TYPE_FIXED_SIZE_LIST
-            term_type = kAdbcColumnTypeFixedSizeList;
-            children_term = get_arrow_array_list_children(env, schema, values, offset, count, level);
+            unsigned n_items = 0;
+            for (size_t i = 3; i < format_len; i++) {
+                n_items = n_items * 10 + (format[i] - '0');
+            }
+            term_type = kAdbcColumnTypeFixedSizeList(n_items);
+            children_term = get_arrow_array_list_children(env, schema, values, offset, count, level, NANOARROW_TYPE_FIXED_SIZE_LIST, n_items);
         } else if (format_len >= 3 && strncmp("w:", format, 2) == 0) {
             // NANOARROW_TYPE_FIXED_SIZE_BINARY
             if (count == -1) count = values->length;

--- a/c_src/adbc_arrow_array.hpp
+++ b/c_src/adbc_arrow_array.hpp
@@ -843,6 +843,7 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
             children_term = get_arrow_array_map_children(env, schema, values, offset, count, level);
         } else if (strncmp("+l", format, 2) == 0) {
             // NANOARROW_TYPE_LIST
+            printf("format=%s\n", format);
             term_type = kAdbcColumnTypeList;
             children_term = get_arrow_array_list_children(env, schema, values, offset, count, level);
         } else if (strncmp("+L", format, 2) == 0) {

--- a/c_src/adbc_column.hpp
+++ b/c_src/adbc_column.hpp
@@ -860,21 +860,25 @@ int adbc_column_to_adbc_field(ErlNifEnv *env, ERL_NIF_TERM adbc_buffer, struct A
     NANOARROW_RETURN_NOT_OK(ArrowSchemaSetMetadata(schema_out, (const char*)metadata_buffer.data));
     ArrowBufferReset(&metadata_buffer);
 
+    // Data types can be found here:
+    // https://arrow.apache.org/docs/format/CDataInterface.html
     int ret = kErrorBufferUnknownType;
-    if (enif_is_identical(type_term, kAdbcColumnTypeI8)) {
+    if (enif_is_identical(type_term, kAdbcColumnTypeBool)) {
+        ret = do_get_list_boolean(env, data_term, nullable, NANOARROW_TYPE_BOOL, array_out, schema_out, error_out);
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeI8)) {
         ret = do_get_list_integer<int8_t>(env, data_term, nullable, NANOARROW_TYPE_INT8, array_out, schema_out, error_out);
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeI16)) {
-        ret = do_get_list_integer<int16_t>(env, data_term, nullable, NANOARROW_TYPE_INT16, array_out, schema_out, error_out);
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeI32)) {
-        ret = do_get_list_integer<int32_t>(env, data_term, nullable, NANOARROW_TYPE_INT32, array_out, schema_out, error_out);
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeI64)) {
-        ret = do_get_list_integer<int64_t>(env, data_term, nullable, NANOARROW_TYPE_INT64, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeU8)) {
         ret = do_get_list_integer<uint8_t>(env, data_term, nullable, NANOARROW_TYPE_UINT8, array_out, schema_out, error_out);
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeI16)) {
+        ret = do_get_list_integer<int16_t>(env, data_term, nullable, NANOARROW_TYPE_INT16, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeU16)) {
         ret = do_get_list_integer<uint16_t>(env, data_term, nullable, NANOARROW_TYPE_UINT16, array_out, schema_out, error_out);
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeI32)) {
+        ret = do_get_list_integer<int32_t>(env, data_term, nullable, NANOARROW_TYPE_INT32, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeU32)) {
         ret = do_get_list_integer<uint32_t>(env, data_term, nullable, NANOARROW_TYPE_UINT32, array_out, schema_out, error_out);
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeI64)) {
+        ret = do_get_list_integer<int64_t>(env, data_term, nullable, NANOARROW_TYPE_INT64, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeU64)) {
         ret = do_get_list_integer<uint64_t>(env, data_term, nullable, NANOARROW_TYPE_UINT64, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeF16)) {
@@ -883,20 +887,18 @@ int adbc_column_to_adbc_field(ErlNifEnv *env, ERL_NIF_TERM adbc_buffer, struct A
         ret = do_get_list_float(env, data_term, nullable, NANOARROW_TYPE_FLOAT, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeF64)) {
         ret = do_get_list_float(env, data_term, nullable, NANOARROW_TYPE_DOUBLE, array_out, schema_out, error_out);
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeString)) {
-        ret = do_get_list_string(env, data_term, nullable, NANOARROW_TYPE_STRING, array_out, schema_out, error_out);
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeLargeString)) {
-        ret = do_get_list_string(env, data_term, nullable, NANOARROW_TYPE_LARGE_STRING, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeBinary)) {
         ret = do_get_list_string(env, data_term, nullable, NANOARROW_TYPE_BINARY, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeLargeBinary)) {
         ret = do_get_list_string(env, data_term, nullable, NANOARROW_TYPE_LARGE_BINARY, array_out, schema_out, error_out);
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeString)) {
+        ret = do_get_list_string(env, data_term, nullable, NANOARROW_TYPE_STRING, array_out, schema_out, error_out);
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeLargeString)) {
+        ret = do_get_list_string(env, data_term, nullable, NANOARROW_TYPE_LARGE_STRING, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeDate32)) {
         ret = do_get_list_date(env, data_term, nullable, NANOARROW_TYPE_DATE32, array_out, schema_out, error_out);
     } else if (enif_is_identical(type_term, kAdbcColumnTypeDate64)) {
         ret = do_get_list_date(env, data_term, nullable, NANOARROW_TYPE_DATE64, array_out, schema_out, error_out);
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeBool)) {
-        ret = do_get_list_boolean(env, data_term, nullable, NANOARROW_TYPE_BOOL, array_out, schema_out, error_out);
     } else if (enif_is_tuple(env, type_term)) {        
         if (enif_is_identical(type_term, kAdbcColumnTypeTime32Seconds)) {
             // NANOARROW_TYPE_TIME32

--- a/c_src/adbc_column.hpp
+++ b/c_src/adbc_column.hpp
@@ -1333,10 +1333,6 @@ int adbc_column_to_adbc_field(ErlNifEnv *env, ERL_NIF_TERM adbc_buffer, struct A
         enif_snprintf(error_out->message, sizeof(error_out->message), "type `%T` not supported yet.", type_term);
     }
     return ret;
-    if (ret == kErrorBufferUnknownType) {
-        enif_snprintf(error_out->message, sizeof(error_out->message), "type `%T` not supported yet.", type_term);
-    }
-    return ret; 
 }
 
 // non-zero return value indicating errors

--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -101,5 +101,6 @@ constexpr int kErrorBufferUnknownType = 6;
 constexpr int kErrorBufferGetMetadataKey = 7;
 constexpr int kErrorBufferGetMetadataValue = 8;
 constexpr int kErrorExpectedCalendarISO = 9;
+constexpr int kErrorInternalError = 10;
 
 #endif  // ADBC_CONSTS_H

--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -16,6 +16,7 @@ static ERL_NIF_TERM kAtomStructKey;
 
 static ERL_NIF_TERM kAtomDecimal;
 static ERL_NIF_TERM kAtomFixedSizeBinary;
+static ERL_NIF_TERM kAtomFixedSizeList;
 static ERL_NIF_TERM kAtomTime32;
 static ERL_NIF_TERM kAtomTime64;
 static ERL_NIF_TERM kAtomTimestamp;
@@ -85,7 +86,7 @@ static ERL_NIF_TERM kAdbcColumnTypeDate64;
 #define kAdbcColumnTypeIntervalMonthDayNano enif_make_tuple2(env, kAtomInterval, kAtomMonthDayNano)
 static ERL_NIF_TERM kAdbcColumnTypeList;
 static ERL_NIF_TERM kAdbcColumnTypeLargeList;
-static ERL_NIF_TERM kAdbcColumnTypeFixedSizeList;
+#define kAdbcColumnTypeFixedSizeList(n_items) enif_make_tuple2(env, kAtomFixedSizeBinary, enif_make_int64(env, n_items))
 static ERL_NIF_TERM kAdbcColumnTypeStruct;
 static ERL_NIF_TERM kAdbcColumnTypeMap;
 static ERL_NIF_TERM kAdbcColumnTypeDenseUnion;

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -794,6 +794,7 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
 
     kAtomDecimal = erlang::nif::atom(env, "decimal");
     kAtomFixedSizeBinary = erlang::nif::atom(env, "fixed_size_binary");
+    kAtomFixedSizeList = erlang::nif::atom(env, "fixed_size_list");
     kAtomTime32 = erlang::nif::atom(env, "time32");
     kAtomTime64 = erlang::nif::atom(env, "time64");
     kAtomTimestamp = erlang::nif::atom(env, "timestamp");
@@ -849,7 +850,6 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAdbcColumnTypeDate64 = erlang::nif::atom(env, "date64");
     kAdbcColumnTypeList = erlang::nif::atom(env, "list");
     kAdbcColumnTypeLargeList = erlang::nif::atom(env, "large_list");
-    kAdbcColumnTypeFixedSizeList = erlang::nif::atom(env, "fixed_size_list");
     kAdbcColumnTypeStruct = erlang::nif::atom(env, "struct");
     kAdbcColumnTypeMap = erlang::nif::atom(env, "map");
     kAdbcColumnTypeDenseUnion = erlang::nif::atom(env, "dense_union");

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -996,4 +996,14 @@ defmodule Adbc.Column do
   def interval(data, :month_day_nano, opts) do
     column({:interval, :month_day_nano}, data, opts)
   end
+
+  def list(data, opts \\ [])
+
+  def list(%Adbc.Column{}=data, opts) do
+    column(:list, [data], opts)
+  end
+
+  def list(data, opts) do
+    column(:list, data, opts)
+  end
 end

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -1016,6 +1016,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
+  @spec list([%Adbc.Column{} | nil], Keyword.t()) :: %Adbc.Column{}
   def list(data, opts \\ []) when is_list(data) do
     column(:list, data, opts)
   end
@@ -1039,7 +1040,35 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
+  @spec large_list([%Adbc.Column{} | nil], Keyword.t()) :: %Adbc.Column{}
   def large_list(data, opts \\ []) when is_list(data) do
     column(:large_list, data, opts)
+  end
+
+  @doc """
+  Similar to `list/2`, but the length of the list is the same.
+
+  ## Arguments
+
+  * `data`: a list, each element of which can be one of the following:
+    - `nil`
+    - `Adbc.Column`
+
+    Note that each `Adbc.Column` in the list should have the same type and length.
+
+  * `fixed_size`: The fixed size of the list.
+
+  * `opts`: A keyword list of options
+
+  ## Options
+
+  * `:name` - The name of the column
+  * `:nullable` - A boolean value indicating whether the column is nullable
+  * `:metadata` - A map of metadata
+  """
+  @spec fixed_size_list([%Adbc.Column{} | nil], [i32()], Keyword.t()) ::
+          %Adbc.Column{}
+  def fixed_size_list(data, fixed_size, opts \\ []) when is_list(data) do
+    column({:fixed_size_list, fixed_size}, data, opts)
   end
 end

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -997,13 +997,26 @@ defmodule Adbc.Column do
     column({:interval, :month_day_nano}, data, opts)
   end
 
-  def list(data, opts \\ [])
+  @doc """
+  A column that each row is a list of some type or nil.
 
-  def list(%Adbc.Column{}=data, opts) do
-    column(:list, [data], opts)
-  end
+  ## Arguments
 
-  def list(data, opts) do
+  * `data`: a list, each element of which can be one of the following:
+    - `nil`
+    - `Adbc.Column`
+
+    Note that each `Adbc.Column` in the list should have the same type.
+
+  * `opts`: A keyword list of options
+
+  ## Options
+
+  * `:name` - The name of the column
+  * `:nullable` - A boolean value indicating whether the column is nullable
+  * `:metadata` - A map of metadata
+  """
+  def list(data, opts \\ []) when is_list(data) do
     column(:list, data, opts)
   end
 end

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -1019,4 +1019,27 @@ defmodule Adbc.Column do
   def list(data, opts \\ []) when is_list(data) do
     column(:list, data, opts)
   end
+
+  @doc """
+  Similar to `list/2`, but for large lists.
+
+  ## Arguments
+
+  * `data`: a list, each element of which can be one of the following:
+    - `nil`
+    - `Adbc.Column`
+
+    Note that each `Adbc.Column` in the list should have the same type.
+
+  * `opts`: A keyword list of options
+
+  ## Options
+
+  * `:name` - The name of the column
+  * `:nullable` - A boolean value indicating whether the column is nullable
+  * `:metadata` - A map of metadata
+  """
+  def large_list(data, opts \\ []) when is_list(data) do
+    column(:large_list, data, opts)
+  end
 end

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -331,15 +331,7 @@ defmodule Adbc.Connection.Test do
                          type: :list,
                          nullable: false,
                          metadata: nil,
-                         data: [
-                           %Adbc.Column{
-                             name: "item",
-                             type: :string,
-                             nullable: false,
-                             metadata: nil,
-                             data: []
-                           }
-                         ]
+                         data: []
                        },
                        %Adbc.Column{
                          name: "constraint_column_usage",
@@ -419,7 +411,7 @@ defmodule Adbc.Connection.Test do
                      [
                        {"constraint_name", []},
                        {"constraint_type", []},
-                       {"constraint_column_names", [[]]},
+                       {"constraint_column_names", []},
                        {"constraint_column_usage",
                         [
                           {"fk_catalog", []},

--- a/test/adbc_test.exs
+++ b/test/adbc_test.exs
@@ -47,6 +47,32 @@ defmodule AdbcTest do
                Connection.query(conn, "SELECT 123 as num")
     end
 
+    test "list paramters for query", %{conn: conn} do
+      assert {:ok,
+              %Adbc.Result{
+                data: [
+                  %Adbc.Column{
+                    name: "num",
+                    type: :list,
+                    nullable: true,
+                    metadata: nil,
+                    data: [
+                      %Adbc.Column{
+                        name: "item",
+                        type: :i32,
+                        nullable: true,
+                        metadata: nil,
+                        data: [1, 2, 3]
+                      }
+                    ]
+                  }
+                ]
+              }} =
+               Connection.query(conn, "SELECT ANY(?1::INT[]) as num", [
+                Adbc.Column.list(Adbc.Column.i32([1,2,3], name: "item"))
+               ])
+    end
+
     test "list responses", %{conn: conn} do
       assert {:ok,
               %Adbc.Result{

--- a/test/adbc_test.exs
+++ b/test/adbc_test.exs
@@ -47,32 +47,6 @@ defmodule AdbcTest do
                Connection.query(conn, "SELECT 123 as num")
     end
 
-    test "list paramters for query", %{conn: conn} do
-      assert {:ok,
-              %Adbc.Result{
-                data: [
-                  %Adbc.Column{
-                    name: "num",
-                    type: :list,
-                    nullable: true,
-                    metadata: nil,
-                    data: [
-                      %Adbc.Column{
-                        name: "item",
-                        type: :i32,
-                        nullable: true,
-                        metadata: nil,
-                        data: [1, 2, 3]
-                      }
-                    ]
-                  }
-                ]
-              }} =
-               Connection.query(conn, "SELECT ANY(?1::INT[]) as num", [
-                Adbc.Column.list(Adbc.Column.i32([1,2,3], name: "item"))
-               ])
-    end
-
     test "list responses", %{conn: conn} do
       assert {:ok,
               %Adbc.Result{


### PR DESCRIPTION
This PR implemented list types:

- `Adbc.Column.list`
- `Adbc.Column.large_list`
- `Adbc.Column.fixed_size_list`

It also supports simple nested ones (all primitive types), such as 

```elixir
assert {:ok,
        %Adbc.Result{
          data: [
            %Adbc.Column{
              data: [
                nil,
                %Adbc.Column{
                  name: "item",
                  type: :i32,
                  nullable: true,
                  metadata: nil,
                  data: [1, 2, 3]
                },
                nil,
                %Adbc.Column{
                  name: "item",
                  type: :i32,
                  nullable: true,
                  metadata: nil,
                  data: [4, 5, 6]
                }
              ],
              metadata: nil,
              name: "",
              nullable: true,
              type: :list
            }
          ],
          num_rows: 4
        }} ==
          Adbc.Connection.query(conn, "passthrough", [
            Adbc.Column.list([
              nil,
              Adbc.Column.i32([1, 2, 3]),
              nil,
              Adbc.Column.i32([4, 5, 6])
            ])
          ])
```

But it's not yet ready for nesting another list in a list, I'll implement that in another PR. Currently it will raise an error message if we do something like

```elixir
{:error, %ArgumentError{__exception__: true, message: "nested types are not supported yet"}} = Adbc.Connection.query(conn, "some query", [
  Adbc.Column.list([
    Adbc.Column.list([
      Adbc.Column.i32([1, 2, 3]),
      Adbc.Column.i32([4, 5, 6])
    ])
  ])
])
```