### PR TITLE
feat: add support for decoding list views and large list views

### DIFF
--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -13,6 +13,29 @@ static ERL_NIF_TERM kAtomNegInfinity;
 static ERL_NIF_TERM kAtomNaN;
 static ERL_NIF_TERM kAtomEndOfSeries;
 static ERL_NIF_TERM kAtomStructKey;
+// for the data field in list views and large list views
+// %Adbc.Column{
+//   name: "sample_list_view",
+//   type: :list_view,
+//   nullable: true,
+//   metadata: %{},
+//   data: %{
+//     validity: [true, false, true, true, true],
+//     offsets: [4, 7, 0, 0, 3],
+//     sizes: [3, 0, 4, 0, 2],
+//     values: %Adbc.Column{
+//       name: "sample_list",
+//       type: :i32,
+//       nullable: false,
+//       metadata: %{},
+//       data: [0, -127, 127, 50, 12, -7, 25]
+//     }
+//   }
+// }
+static ERL_NIF_TERM kAtomValidity;
+static ERL_NIF_TERM kAtomOffsets;
+static ERL_NIF_TERM kAtomSizes;
+static ERL_NIF_TERM kAtomValues;
 
 static ERL_NIF_TERM kAtomDecimal;
 static ERL_NIF_TERM kAtomFixedSizeBinary;
@@ -86,6 +109,8 @@ static ERL_NIF_TERM kAdbcColumnTypeDate64;
 #define kAdbcColumnTypeIntervalMonthDayNano enif_make_tuple2(env, kAtomInterval, kAtomMonthDayNano)
 static ERL_NIF_TERM kAdbcColumnTypeList;
 static ERL_NIF_TERM kAdbcColumnTypeLargeList;
+static ERL_NIF_TERM kAdbcColumnTypeListView;
+static ERL_NIF_TERM kAdbcColumnTypeLargeListView;
 #define kAdbcColumnTypeFixedSizeList(n_items) enif_make_tuple2(env, kAtomFixedSizeBinary, enif_make_int64(env, n_items))
 static ERL_NIF_TERM kAdbcColumnTypeStruct;
 static ERL_NIF_TERM kAdbcColumnTypeMap;

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -791,6 +791,10 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAtomNaN = erlang::nif::atom(env, "nan");
     kAtomEndOfSeries = erlang::nif::atom(env, "end_of_series");
     kAtomStructKey = erlang::nif::atom(env, "__struct__");
+    kAtomValidity = erlang::nif::atom(env, "validity");
+    kAtomOffsets = erlang::nif::atom(env, "offsets");
+    kAtomSizes = erlang::nif::atom(env, "sizes");
+    kAtomValues = erlang::nif::atom(env, "values");
 
     kAtomDecimal = erlang::nif::atom(env, "decimal");
     kAtomFixedSizeBinary = erlang::nif::atom(env, "fixed_size_binary");
@@ -850,6 +854,8 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAdbcColumnTypeDate64 = erlang::nif::atom(env, "date64");
     kAdbcColumnTypeList = erlang::nif::atom(env, "list");
     kAdbcColumnTypeLargeList = erlang::nif::atom(env, "large_list");
+    kAdbcColumnTypeListView = erlang::nif::atom(env, "list_view");
+    kAdbcColumnTypeLargeListView = erlang::nif::atom(env, "large_list_view");
     kAdbcColumnTypeStruct = erlang::nif::atom(env, "struct");
     kAdbcColumnTypeMap = erlang::nif::atom(env, "map");
     kAdbcColumnTypeDenseUnion = erlang::nif::atom(env, "dense_union");

--- a/lib/adbc_result.ex
+++ b/lib/adbc_result.ex
@@ -27,6 +27,10 @@ defmodule Adbc.Result do
     end)
   end
 
+  def list_view_to_list(%Adbc.Result{data: data}) do
+    Enum.map(data, &list_to_map/1)
+  end
+
   defp list_to_map(%Adbc.Column{name: name, type: type, data: data}) do
     case type do
       :list ->

--- a/test/adbc_column_test.exs
+++ b/test/adbc_column_test.exs
@@ -1,5 +1,6 @@
 defmodule Adbc.Column.Test do
   use ExUnit.Case
+  doctest Adbc.Column
 
   describe "decimals" do
     test "integers" do
@@ -11,7 +12,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                data: [decimal_data, value_data],
-               metadata: nil,
+               metadata: %{},
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
@@ -27,7 +28,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                data: [decimal_data, value_data],
-               metadata: nil,
+               metadata: %{},
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
@@ -53,7 +54,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                data: [data],
-               metadata: nil,
+               metadata: %{},
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
@@ -66,7 +67,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                data: [data],
-               metadata: nil,
+               metadata: %{},
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
@@ -111,7 +112,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                data: [decimal_data, value_data],
-               metadata: nil,
+               metadata: %{},
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
@@ -127,7 +128,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                data: [decimal_data, value_data],
-               metadata: nil,
+               metadata: %{},
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
@@ -166,7 +167,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                data: [data],
-               metadata: nil,
+               metadata: %{},
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}
@@ -179,7 +180,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                data: [data],
-               metadata: nil,
+               metadata: %{},
                name: nil,
                nullable: false,
                type: {:decimal, ^bitwidth, ^precision, ^scale}


### PR DESCRIPTION
This PR adds support for decoding list views and large list views. 

The result by default is represented in the following format, where `data` is a map consisting 4 key-value pairs:

- `validity`, indicating if the corresponding child is valid or not (`nil` for invalid ones)
- `offsets`, the index where first element of the child list in `values.data`
- `sizes`, the length of the corresponding child
- `values`, the underlying values

```elixir
iex> list_view = %Adbc.Column{
  name: "sample_list_view",
  type: :list_view,
  nullable: true,
  metadata: %{},
  data: %{
    validity: [true, false, true, true, true],
    offsets: [4, 7, 0, 0, 3],
    sizes: [3, 0, 4, 0, 2],
    values: %Adbc.Column{
      name: "item",
      type: :i32,
      nullable: false,
      metadata: %{},
      data: [0, -127, 127, 50, 12, -7, 25]
    }
  }
}
```

To convert from the compact form to lists, users can use 

```elixir
iex> Adbc.Column.list_view_to_list(list_view)
%Adbc.Column{
  name: "sample_list_view",
  type: :list,
  nullable: true,
  metadata: %{},
  data: [
    %Adbc.Column{
      name: "item",
      type: :i32,
      nullable: false,
      metadata: nil,
      data: [12, -7, 25]
    },
    nil,
    %Adbc.Column{
      name: "item",
      type: :i32,
      nullable: false,
      metadata: nil,
      data: [0, -127, 127, 50]
    },
    %Adbc.Column{
      name: "item",
      type: :i32,
      nullable: false,
      metadata: nil,
      data: []
    },
    %Adbc.Column{
      name: "item",
      type: :i32,
      nullable: false,
      metadata: nil,
      data: ~c"2\f"
    }
  ]
}
```

The example is taken from https://arrow.apache.org/docs/format/Columnar.html#listview-layout