### PR TITLE
renamed functions `i{8,16,32,64}` => `s{8,16,32,64}`

### DIFF
--- a/c_src/adbc_arrow_array.hpp
+++ b/c_src/adbc_arrow_array.hpp
@@ -805,7 +805,6 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
 
     if (!skip_dictionary_check) {
         if (schema->dictionary != nullptr && values->dictionary != nullptr) {
-            printf("schema->dictionary != nullptr && values->dictionary != nullptr\n");
             // NANOARROW_TYPE_DICTIONARY
             //
             // For dictionary-encoded arrays, the ArrowSchema.format string 
@@ -849,7 +848,7 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
         } else if (format[0] == 'l') {
             // NANOARROW_TYPE_INT64
             using value_type = int64_t;
-            term_type = kAdbcColumnTypeI64;
+            term_type = kAdbcColumnTypeS64;
             if (count == -1) count = values->length;
             if (count > values->length) count = values->length - offset;
             if (values->n_buffers != 2) {
@@ -867,7 +866,7 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
         } else if (format[0] == 'c') {
             // NANOARROW_TYPE_INT8
             using value_type = int8_t;
-            term_type = kAdbcColumnTypeI8;
+            term_type = kAdbcColumnTypeS8;
             if (count == -1) count = values->length;
             if (count > values->length) count = values->length - offset;
             if (values->n_buffers != 2) {
@@ -885,7 +884,7 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
         } else if (format[0] == 's') {
             // NANOARROW_TYPE_INT16
             using value_type = int16_t;
-            term_type = kAdbcColumnTypeI16;
+            term_type = kAdbcColumnTypeS16;
             if (count == -1) count = values->length;
             if (count > values->length) count = values->length - offset;
             if (values->n_buffers != 2) {
@@ -903,7 +902,7 @@ int arrow_array_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, struct 
         } else if (format[0] == 'i') {
             // NANOARROW_TYPE_INT32
             using value_type = int32_t;
-            term_type = kAdbcColumnTypeI32;
+            term_type = kAdbcColumnTypeS32;
             if (count == -1) count = values->length;
             if (count > values->length) count = values->length - offset;
             if (values->n_buffers != 2) {

--- a/c_src/adbc_column.hpp
+++ b/c_src/adbc_column.hpp
@@ -1116,19 +1116,19 @@ struct AdbcColumnType adbc_column_type_to_nanoarrow_type(ErlNifEnv *env, ERL_NIF
 
     if (enif_is_identical(type_term, kAdbcColumnTypeBool)) {
         ret.arrow_type = NANOARROW_TYPE_BOOL;
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeI8)) {
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeS8)) {
         ret.arrow_type = NANOARROW_TYPE_INT8;
     } else if (enif_is_identical(type_term, kAdbcColumnTypeU8)) {
         ret.arrow_type = NANOARROW_TYPE_UINT8;
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeI16)) {
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeS16)) {
         ret.arrow_type = NANOARROW_TYPE_INT16;
     } else if (enif_is_identical(type_term, kAdbcColumnTypeU16)) {
         ret.arrow_type = NANOARROW_TYPE_UINT16;
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeI32)) {
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeS32)) {
         ret.arrow_type = NANOARROW_TYPE_INT32;
     } else if (enif_is_identical(type_term, kAdbcColumnTypeU32)) {
         ret.arrow_type = NANOARROW_TYPE_UINT32;
-    } else if (enif_is_identical(type_term, kAdbcColumnTypeI64)) {
+    } else if (enif_is_identical(type_term, kAdbcColumnTypeS64)) {
         ret.arrow_type = NANOARROW_TYPE_INT64;
     } else if (enif_is_identical(type_term, kAdbcColumnTypeU64)) {
         ret.arrow_type = NANOARROW_TYPE_UINT64;

--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -27,7 +27,7 @@ static ERL_NIF_TERM kAtomStructKey;
 //     sizes: [3, 0, 4, 0, 2],
 //     values: %Adbc.Column{
 //       name: "sample_list",
-//       type: :i32,
+//       type: :s32,
 //       nullable: false,
 //       metadata: nil,
 //       data: [0, -127, 127, 50, 12, -7, 25]
@@ -82,13 +82,13 @@ static ERL_NIF_TERM kAtomDataKey;
 
 // https://arrow.apache.org/docs/format/CDataInterface.html
 static ERL_NIF_TERM kAdbcColumnTypeBool;
-static ERL_NIF_TERM kAdbcColumnTypeI8;
+static ERL_NIF_TERM kAdbcColumnTypeS8;
 static ERL_NIF_TERM kAdbcColumnTypeU8;
-static ERL_NIF_TERM kAdbcColumnTypeI16;
+static ERL_NIF_TERM kAdbcColumnTypeS16;
 static ERL_NIF_TERM kAdbcColumnTypeU16;
-static ERL_NIF_TERM kAdbcColumnTypeI32;
+static ERL_NIF_TERM kAdbcColumnTypeS32;
 static ERL_NIF_TERM kAdbcColumnTypeU32;
-static ERL_NIF_TERM kAdbcColumnTypeI64;
+static ERL_NIF_TERM kAdbcColumnTypeS64;
 static ERL_NIF_TERM kAdbcColumnTypeU64;
 static ERL_NIF_TERM kAdbcColumnTypeF16;
 static ERL_NIF_TERM kAdbcColumnTypeF32;

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -840,13 +840,13 @@ static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
     kAtomDataKey = erlang::nif::atom(env, "data");
 
     kAdbcColumnTypeBool = erlang::nif::atom(env, "boolean");
-    kAdbcColumnTypeI8 = erlang::nif::atom(env, "i8");
+    kAdbcColumnTypeS8 = erlang::nif::atom(env, "s8");
     kAdbcColumnTypeU8 = erlang::nif::atom(env, "u8");
-    kAdbcColumnTypeI16 = erlang::nif::atom(env, "i16");
+    kAdbcColumnTypeS16 = erlang::nif::atom(env, "s16");
     kAdbcColumnTypeU16 = erlang::nif::atom(env, "u16");
-    kAdbcColumnTypeI32 = erlang::nif::atom(env, "i32");
+    kAdbcColumnTypeS32 = erlang::nif::atom(env, "s32");
     kAdbcColumnTypeU32 = erlang::nif::atom(env, "u32");
-    kAdbcColumnTypeI64 = erlang::nif::atom(env, "i64");
+    kAdbcColumnTypeS64 = erlang::nif::atom(env, "s64");
     kAdbcColumnTypeU64 = erlang::nif::atom(env, "u64");
     kAdbcColumnTypeF16 = erlang::nif::atom(env, "f16");
     kAdbcColumnTypeF32 = erlang::nif::atom(env, "f32");

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -10,19 +10,19 @@ defmodule Adbc.Column do
 
   import Bitwise
 
-  @type i8 :: -128..127
+  @type s8 :: -128..127
   @type u8 :: 0..255
-  @type i16 :: -32768..32767
+  @type s16 :: -32768..32767
   @type u16 :: 0..65535
-  @type i32 :: -2_147_483_648..2_147_483_647
+  @type s32 :: -2_147_483_648..2_147_483_647
   @type u32 :: 0..4_294_967_295
-  @type i64 :: -9_223_372_036_854_775_808..9_223_372_036_854_775_807
+  @type s64 :: -9_223_372_036_854_775_808..9_223_372_036_854_775_807
   @type u64 :: 0..18_446_744_073_709_551_615
   @type signed_integer ::
-          :i8
-          | :i16
-          | :i32
-          | :i64
+          :s8
+          | :s16
+          | :s32
+          | :s64
   @type unsigned_integer ::
           :u8
           | :u16
@@ -60,9 +60,9 @@ defmodule Adbc.Column do
           | {:duration, :milliseconds}
           | {:duration, :microseconds}
           | {:duration, :nanoseconds}
-  @type interval_month :: i32()
-  @type interval_day_time :: {i32(), i32()}
-  @type interval_month_day_nano :: {i32(), i32(), i64()}
+  @type interval_month :: s32()
+  @type interval_day_time :: {s32(), s32()}
+  @type interval_month_day_nano :: {s32(), s32(), s64()}
   @type interval_unit ::
           :month
           | :day_time
@@ -81,7 +81,7 @@ defmodule Adbc.Column do
           sizes: [non_neg_integer()],
           values: %Adbc.Column{}
         }
-  @valid_run_end_types [:i16, :i32, :i64]
+  @valid_run_end_types [:s16, :s32, :s64]
   @type dictionary_data_t :: %{
           key: %Adbc.Column{},
           value: %Adbc.Column{}
@@ -95,7 +95,7 @@ defmodule Adbc.Column do
           | :large_list
           | :list_view
           | :large_list_view
-          | {:fixed_size_list, i32()}
+          | {:fixed_size_list, s32()}
           | :binary
           | :large_binary
           | :string
@@ -324,19 +324,19 @@ defmodule Adbc.Column do
 
   ## Examples
 
-      iex> Adbc.Column.i8([1, 2, 3])
+      iex> Adbc.Column.s8([1, 2, 3])
       %Adbc.Column{
         name: nil,
-        type: :i8,
+        type: :s8,
         nullable: false,
         metadata: nil,
         data: [1, 2, 3]
       }
 
   """
-  @spec i8([i8() | nil], Keyword.t()) :: %Adbc.Column{}
-  def i8(data, opts \\ []) when is_list(data) and is_list(opts) do
-    column(:i8, data, opts)
+  @spec s8([s8() | nil], Keyword.t()) :: %Adbc.Column{}
+  def s8(data, opts \\ []) when is_list(data) and is_list(opts) do
+    column(:s8, data, opts)
   end
 
   @doc """
@@ -355,19 +355,19 @@ defmodule Adbc.Column do
 
   ## Examples
 
-      iex> Adbc.Column.i16([1, 2, 3])
+      iex> Adbc.Column.s16([1, 2, 3])
       %Adbc.Column{
         name: nil,
-        type: :i16,
+        type: :s16,
         nullable: false,
         metadata: nil,
         data: [1, 2, 3]
       }
 
   """
-  @spec i16([i16() | nil], Keyword.t()) :: %Adbc.Column{}
-  def i16(data, opts \\ []) when is_list(data) and is_list(opts) do
-    column(:i16, data, opts)
+  @spec s16([s16() | nil], Keyword.t()) :: %Adbc.Column{}
+  def s16(data, opts \\ []) when is_list(data) and is_list(opts) do
+    column(:s16, data, opts)
   end
 
   @doc """
@@ -386,19 +386,19 @@ defmodule Adbc.Column do
 
   ## Examples
 
-      iex> Adbc.Column.i32([1, 2, 3])
+      iex> Adbc.Column.s32([1, 2, 3])
       %Adbc.Column{
         name: nil,
-        type: :i32,
+        type: :s32,
         nullable: false,
         metadata: nil,
         data: [1, 2, 3]
       }
 
   """
-  @spec i32([i32() | nil], Keyword.t()) :: %Adbc.Column{}
-  def i32(data, opts \\ []) when is_list(data) and is_list(opts) do
-    column(:i32, data, opts)
+  @spec s32([s32() | nil], Keyword.t()) :: %Adbc.Column{}
+  def s32(data, opts \\ []) when is_list(data) and is_list(opts) do
+    column(:s32, data, opts)
   end
 
   @doc """
@@ -417,19 +417,19 @@ defmodule Adbc.Column do
 
   ## Examples
 
-      iex> Adbc.Column.i64([1, 2, 3])
+      iex> Adbc.Column.s64([1, 2, 3])
       %Adbc.Column{
         name: nil,
-        type: :i64,
+        type: :s64,
         nullable: false,
         metadata: nil,
         data: [1, 2, 3]
       }
 
   """
-  @spec i64([i64() | nil], Keyword.t()) :: %Adbc.Column{}
-  def i64(data, opts \\ []) when is_list(data) and is_list(opts) do
-    column(:i64, data, opts)
+  @spec s64([s64() | nil], Keyword.t()) :: %Adbc.Column{}
+  def s64(data, opts \\ []) when is_list(data) and is_list(opts) do
+    column(:s64, data, opts)
   end
 
   @doc """
@@ -812,7 +812,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
-  @spec date32([Date.t() | i32() | nil], Keyword.t()) :: %Adbc.Column{}
+  @spec date32([Date.t() | s32() | nil], Keyword.t()) :: %Adbc.Column{}
   def date32(data, opts \\ []) when is_list(data) and is_list(opts) do
     column(:date32, data, opts)
   end
@@ -832,7 +832,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
-  @spec date64([Date.t() | i64() | nil], Keyword.t()) :: %Adbc.Column{}
+  @spec date64([Date.t() | s64() | nil], Keyword.t()) :: %Adbc.Column{}
   def date64(data, opts \\ []) when is_list(data) and is_list(opts) do
     column(:date64, data, opts)
   end
@@ -864,7 +864,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
-  @spec time([Time.t() | nil] | [i64() | nil], time_unit(), Keyword.t()) :: %Adbc.Column{}
+  @spec time([Time.t() | nil] | [s64() | nil], time_unit(), Keyword.t()) :: %Adbc.Column{}
   def time(data, unit, opts \\ [])
 
   def time(data, :seconds, opts) when is_list(data) and is_list(opts) do
@@ -908,7 +908,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
-  @spec timestamp([NaiveDateTime.t() | nil] | [i64() | nil], time_unit(), String.t(), Keyword.t()) ::
+  @spec timestamp([NaiveDateTime.t() | nil] | [s64() | nil], time_unit(), String.t(), Keyword.t()) ::
           %Adbc.Column{}
   def timestamp(data, unit, timezone, opts \\ [])
 
@@ -953,7 +953,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
-  @spec duration([i64() | nil], time_unit(), Keyword.t()) :: %Adbc.Column{}
+  @spec duration([s64() | nil], time_unit(), Keyword.t()) :: %Adbc.Column{}
   def duration(data, unit, opts \\ [])
 
   def duration(data, :seconds, opts) when is_list(data) and is_list(opts) do
@@ -1091,7 +1091,7 @@ defmodule Adbc.Column do
   * `:nullable` - A boolean value indicating whether the column is nullable
   * `:metadata` - A map of metadata
   """
-  @spec fixed_size_list([%Adbc.Column{} | nil], i32(), Keyword.t()) ::
+  @spec fixed_size_list([%Adbc.Column{} | nil], s32(), Keyword.t()) ::
           %Adbc.Column{}
   def fixed_size_list(data, fixed_size, opts \\ []) when is_list(data) do
     column({:fixed_size_list, fixed_size}, data, opts)
@@ -1121,7 +1121,7 @@ defmodule Adbc.Column do
   ```elixir
   Adbc.Column.dictionary(
     Adbc.Column.string(["foo", "bar", "baz"], nullable: true),
-    Adbc.Column.i32([0, 1, 0, 1, nil, 2], nullable: true)
+    Adbc.Column.s32([0, 1, 0, 1, nil, 2], nullable: true)
   )
   ```
 
@@ -1143,7 +1143,7 @@ defmodule Adbc.Column do
   """
   @spec dictionary(%Adbc.Column{}, %Adbc.Column{}, Keyword.t()) :: %Adbc.Column{}
   def dictionary(key = %Adbc.Column{type: index_type}, value = %Adbc.Column{}, opts \\ [])
-      when index_type in [:i8, :u8, :i16, :u16, :i32, :u32, :i64, :u64] do
+      when index_type in [:s8, :u8, :s16, :u16, :s32, :u32, :s64, :u64] do
     column(:dictionary, %{key: key, value: value}, opts)
   end
 
@@ -1160,7 +1160,7 @@ defmodule Adbc.Column do
       ...>   data: %{
       ...>     values: %Adbc.Column{
       ...>       name: "item",
-      ...>       type: :i32,
+      ...>       type: :s32,
       ...>       nullable: false,
       ...>       metadata: nil,
       ...>       data: [0, -127, 127, 50, 12, -7, 25]
@@ -1181,7 +1181,7 @@ defmodule Adbc.Column do
           validity: [true, false, true, true, true],
           values: %Adbc.Column{
             name: "item",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: [0, -127, 127, 50, 12, -7, 25]
@@ -1197,7 +1197,7 @@ defmodule Adbc.Column do
         data: [
           %Adbc.Column{
             name: "item",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: [12, -7, 25]
@@ -1205,21 +1205,21 @@ defmodule Adbc.Column do
           nil,
           %Adbc.Column{
             name: "item",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: [0, -127, 127, 50]
           },
           %Adbc.Column{
             name: "item",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: []
           },
           %Adbc.Column{
             name: "item",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: ~c"2\f"
@@ -1278,13 +1278,13 @@ defmodule Adbc.Column do
 
     max_allowed_length =
       case run_end_type do
-        :i16 ->
+        :s16 ->
           1 <<< 16
 
-        :i32 ->
+        :s32 ->
           1 <<< 32
 
-        :i64 ->
+        :s64 ->
           1 <<< 64
 
         _ ->

--- a/test/adbc_column_test.exs
+++ b/test/adbc_column_test.exs
@@ -259,7 +259,7 @@ defmodule Adbc.Column.Test do
         data: %{
           values: %Adbc.Column{
             name: "item",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: [0, -127, 127, 50, 12, -7, 25]
@@ -278,7 +278,7 @@ defmodule Adbc.Column.Test do
                data: [
                  inner1 = %Adbc.Column{
                    name: "item",
-                   type: :i32,
+                   type: :s32,
                    nullable: false,
                    metadata: nil,
                    data: [12, -7, 25]
@@ -286,21 +286,21 @@ defmodule Adbc.Column.Test do
                  _inner2 = nil,
                  inner3 = %Adbc.Column{
                    name: "item",
-                   type: :i32,
+                   type: :s32,
                    nullable: false,
                    metadata: nil,
                    data: [0, -127, 127, 50]
                  },
                  inner4 = %Adbc.Column{
                    name: "item",
-                   type: :i32,
+                   type: :s32,
                    nullable: false,
                    metadata: nil,
                    data: []
                  },
                  inner5 = %Adbc.Column{
                    name: "item",
-                   type: :i32,
+                   type: :s32,
                    nullable: false,
                    metadata: nil,
                    data: ~c"2\f"
@@ -333,14 +333,14 @@ defmodule Adbc.Column.Test do
                    data: [
                      ^inner3 = %Adbc.Column{
                        name: "item",
-                       type: :i32,
+                       type: :s32,
                        nullable: false,
                        metadata: nil,
                        data: [0, -127, 127, 50]
                      },
                      ^inner4 = %Adbc.Column{
                        name: "item",
-                       type: :i32,
+                       type: :s32,
                        nullable: false,
                        metadata: nil,
                        data: []
@@ -360,7 +360,7 @@ defmodule Adbc.Column.Test do
                    data: [
                      ^inner1 = %Adbc.Column{
                        name: "item",
-                       type: :i32,
+                       type: :s32,
                        nullable: false,
                        metadata: nil,
                        data: [12, -7, 25]
@@ -376,14 +376,14 @@ defmodule Adbc.Column.Test do
                    data: [
                      ^inner4 = %Adbc.Column{
                        name: "item",
-                       type: :i32,
+                       type: :s32,
                        nullable: false,
                        metadata: nil,
                        data: []
                      },
                      ^inner5 = %Adbc.Column{
                        name: "item",
-                       type: :i32,
+                       type: :s32,
                        nullable: false,
                        metadata: nil,
                        data: ~c"2\f"
@@ -416,7 +416,7 @@ defmodule Adbc.Column.Test do
       #    |- offset = 0                   |- length = 7
       #
       # run-end encoded array:
-      #   run_ends<:i32>: [4, 6, 7]
+      #   run_ends<:s32>: [4, 6, 7]
       #   values<:f32>: [1.0, null, 2.0]
       run_end_array = %Adbc.Column{
         name: "sample_run_end_encoded_array",
@@ -435,7 +435,7 @@ defmodule Adbc.Column.Test do
           },
           run_ends: %Adbc.Column{
             name: "run_ends",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: [4, 6, 7]
@@ -489,12 +489,12 @@ defmodule Adbc.Column.Test do
       #
       # run-end encoded array: `[1, 2, 2]`
       #   <offset = 2, length = 3>
-      #   run_ends<:i32>: [2, 4, 7]
+      #   run_ends<:s32>: [2, 4, 7]
       #   values: `[1, 1, 2]`
       #     {
       #         <offset = 2, length=3>
-      #         run_ends<:i32>: [4, 6],
-      #         values<:i32>: [1, 2]
+      #         run_ends<:s32>: [4, 6],
+      #         values<:s32>: [1, 2]
       #     }
       inner_run_end_array = %Adbc.Column{
         name: "inner_run_end_encoded_array",
@@ -506,14 +506,14 @@ defmodule Adbc.Column.Test do
         data: %{
           run_ends: %Adbc.Column{
             name: "run_ends",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: [4, 6]
           },
           values: %Adbc.Column{
             name: "values",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: [1, 2]
@@ -523,7 +523,7 @@ defmodule Adbc.Column.Test do
 
       assert %Adbc.Column{
                name: "inner_run_end_encoded_array",
-               type: :i32,
+               type: :s32,
                nullable: true,
                metadata: nil,
                data: [1, 1, 2]
@@ -539,7 +539,7 @@ defmodule Adbc.Column.Test do
         data: %{
           run_ends: %Adbc.Column{
             name: "run_ends",
-            type: :i32,
+            type: :s32,
             nullable: false,
             metadata: nil,
             data: [2, 4, 7]
@@ -553,7 +553,7 @@ defmodule Adbc.Column.Test do
                metadata: nil,
                name: "sample_run_end_encoded_array",
                nullable: false,
-               type: :i32
+               type: :s32
              } == Adbc.Column.to_list(run_end_array)
     end
   end
@@ -571,7 +571,7 @@ defmodule Adbc.Column.Test do
       # dictionary
       #    type: VarBinary
       #    values: ['foo', 'bar', 'baz']
-      key = Adbc.Column.i32([0, 1, 0, 1, nil, 2], name: "key", nullable: true)
+      key = Adbc.Column.s32([0, 1, 0, 1, nil, 2], name: "key", nullable: true)
       value = Adbc.Column.string(["foo", "bar", "baz"], name: "value", nullable: false)
       dict = Adbc.Column.dictionary(key, value)
 

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -156,7 +156,7 @@ defmodule Adbc.Connection.Test do
                 data: [
                   %Adbc.Column{
                     name: "num",
-                    type: :i64,
+                    type: :s64,
                     nullable: true,
                     metadata: nil,
                     data: [123]
@@ -170,14 +170,14 @@ defmodule Adbc.Connection.Test do
                 data: [
                   %Adbc.Column{
                     name: "num",
-                    type: :i64,
+                    type: :s64,
                     nullable: true,
                     metadata: nil,
                     data: [123]
                   },
                   %Adbc.Column{
                     name: "bool",
-                    type: :i64,
+                    type: :s64,
                     nullable: true,
                     metadata: nil,
                     data: [1]
@@ -194,7 +194,7 @@ defmodule Adbc.Connection.Test do
                 data: [
                   %Adbc.Column{
                     name: "num",
-                    type: :i64,
+                    type: :s64,
                     nullable: true,
                     metadata: nil,
                     data: [579]
@@ -219,7 +219,7 @@ defmodule Adbc.Connection.Test do
                 data: [
                   %Adbc.Column{
                     name: "num",
-                    type: :i64,
+                    type: :s64,
                     nullable: true,
                     metadata: nil,
                     data: [579]
@@ -239,7 +239,7 @@ defmodule Adbc.Connection.Test do
                 data: [
                   %Adbc.Column{
                     name: "num",
-                    type: :i64,
+                    type: :s64,
                     nullable: true,
                     metadata: nil,
                     data: [579]
@@ -253,7 +253,7 @@ defmodule Adbc.Connection.Test do
                 data: [
                   %Adbc.Column{
                     name: "num",
-                    type: :i64,
+                    type: :s64,
                     nullable: true,
                     metadata: nil,
                     data: [1456]
@@ -272,7 +272,7 @@ defmodule Adbc.Connection.Test do
                data: [
                  %Adbc.Column{
                    name: "num",
-                   type: :i64,
+                   type: :s64,
                    nullable: true,
                    metadata: nil,
                    data: [123]
@@ -285,12 +285,12 @@ defmodule Adbc.Connection.Test do
                data: [
                  %Adbc.Column{
                    name: "num",
-                   type: :i64,
+                   type: :s64,
                    nullable: true,
                    metadata: nil,
                    data: [123]
                  },
-                 %Adbc.Column{name: "bool", type: :i64, nullable: true, metadata: nil, data: [1]}
+                 %Adbc.Column{name: "bool", type: :s64, nullable: true, metadata: nil, data: [1]}
                ]
              } =
                Connection.query!(conn, "SELECT 123 as num, true as bool")
@@ -303,7 +303,7 @@ defmodule Adbc.Connection.Test do
                data: [
                  %Adbc.Column{
                    name: "num",
-                   type: :i64,
+                   type: :s64,
                    nullable: true,
                    metadata: nil,
                    data: [579]
@@ -330,12 +330,12 @@ defmodule Adbc.Connection.Test do
                data: [
                  %Adbc.Column{
                    name: "num",
-                   type: :i64,
+                   type: :s64,
                    nullable: true,
                    metadata: nil,
                    data: [123]
                  },
-                 %Adbc.Column{name: "bool", type: :i64, nullable: true, metadata: nil, data: [1]}
+                 %Adbc.Column{name: "bool", type: :s64, nullable: true, metadata: nil, data: [1]}
                ]
              } =
                Connection.query!(conn, "SELECT 123 as num, true as bool", [],
@@ -350,7 +350,7 @@ defmodule Adbc.Connection.Test do
                data: [
                  %Adbc.Column{
                    name: "num",
-                   type: :i64,
+                   type: :s64,
                    nullable: true,
                    metadata: nil,
                    data: [579]

--- a/test/adbc_sqlite_test.exs
+++ b/test/adbc_sqlite_test.exs
@@ -79,15 +79,15 @@ defmodule Adbc.SQLite.Test do
     {:ok,
      list_result = %Adbc.Result{
        data: [
-         %Adbc.Column{name: "i1", type: :i64, nullable: true, metadata: nil, data: [1]},
-         %Adbc.Column{name: "i2", type: :i64, nullable: true, metadata: nil, data: [2]},
-         %Adbc.Column{name: "i3", type: :i64, nullable: true, metadata: nil, data: [3]},
-         %Adbc.Column{name: "i4", type: :i64, nullable: true, metadata: nil, data: [4]},
-         %Adbc.Column{name: "i5", type: :i64, nullable: true, metadata: nil, data: [5]},
-         %Adbc.Column{name: "i6", type: :i64, nullable: true, metadata: nil, data: [6]},
-         %Adbc.Column{name: "i7", type: :i64, nullable: true, metadata: nil, data: ~c"\a"},
-         %Adbc.Column{name: "i8", type: :i64, nullable: true, metadata: nil, data: ~c"\b"},
-         %Adbc.Column{name: "i9", type: :i64, nullable: true, metadata: nil, data: ~c"\t"},
+         %Adbc.Column{name: "i1", type: :s64, nullable: true, metadata: nil, data: [1]},
+         %Adbc.Column{name: "i2", type: :s64, nullable: true, metadata: nil, data: [2]},
+         %Adbc.Column{name: "i3", type: :s64, nullable: true, metadata: nil, data: [3]},
+         %Adbc.Column{name: "i4", type: :s64, nullable: true, metadata: nil, data: [4]},
+         %Adbc.Column{name: "i5", type: :s64, nullable: true, metadata: nil, data: [5]},
+         %Adbc.Column{name: "i6", type: :s64, nullable: true, metadata: nil, data: [6]},
+         %Adbc.Column{name: "i7", type: :s64, nullable: true, metadata: nil, data: ~c"\a"},
+         %Adbc.Column{name: "i8", type: :s64, nullable: true, metadata: nil, data: ~c"\b"},
+         %Adbc.Column{name: "i9", type: :s64, nullable: true, metadata: nil, data: ~c"\t"},
          %Adbc.Column{name: "t1", type: :string, nullable: true, metadata: nil, data: ["hello"]},
          %Adbc.Column{name: "t2", type: :string, nullable: true, metadata: nil, data: ["world"]},
          %Adbc.Column{
@@ -113,7 +113,7 @@ defmodule Adbc.SQLite.Test do
          %Adbc.Column{name: "r4", type: :f64, nullable: true, metadata: nil, data: [4.4]},
          %Adbc.Column{name: "n1", type: :f64, nullable: true, metadata: nil, data: [1.1]},
          %Adbc.Column{name: "n2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
-         %Adbc.Column{name: "n3", type: :i64, nullable: true, metadata: nil, data: [1]},
+         %Adbc.Column{name: "n3", type: :s64, nullable: true, metadata: nil, data: [1]},
          %Adbc.Column{
            name: "n4",
            type: :string,
@@ -168,10 +168,10 @@ defmodule Adbc.SQLite.Test do
       VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       """,
       [
-        Adbc.Column.i8([1]),
-        Adbc.Column.i16([2]),
-        Adbc.Column.i32([3]),
-        Adbc.Column.i64([4]),
+        Adbc.Column.s8([1]),
+        Adbc.Column.s16([2]),
+        Adbc.Column.s32([3]),
+        Adbc.Column.s64([4]),
         Adbc.Column.u8([5]),
         Adbc.Column.u16([6]),
         Adbc.Column.u32([7]),
@@ -200,15 +200,15 @@ defmodule Adbc.SQLite.Test do
      %Adbc.Result{
        num_rows: nil,
        data: [
-         %Adbc.Column{name: "i1", type: :i64, nullable: true, metadata: nil, data: [1]},
-         %Adbc.Column{name: "i2", type: :i64, nullable: true, metadata: nil, data: [2]},
-         %Adbc.Column{name: "i3", type: :i64, nullable: true, metadata: nil, data: [3]},
-         %Adbc.Column{name: "i4", type: :i64, nullable: true, metadata: nil, data: [4]},
-         %Adbc.Column{name: "i5", type: :i64, nullable: true, metadata: nil, data: [5]},
-         %Adbc.Column{name: "i6", type: :i64, nullable: true, metadata: nil, data: [6]},
-         %Adbc.Column{name: "i7", type: :i64, nullable: true, metadata: nil, data: ~c"\a"},
-         %Adbc.Column{name: "i8", type: :i64, nullable: true, metadata: nil, data: ~c"\b"},
-         %Adbc.Column{name: "i9", type: :i64, nullable: true, metadata: nil, data: ~c"\t"},
+         %Adbc.Column{name: "i1", type: :s64, nullable: true, metadata: nil, data: [1]},
+         %Adbc.Column{name: "i2", type: :s64, nullable: true, metadata: nil, data: [2]},
+         %Adbc.Column{name: "i3", type: :s64, nullable: true, metadata: nil, data: [3]},
+         %Adbc.Column{name: "i4", type: :s64, nullable: true, metadata: nil, data: [4]},
+         %Adbc.Column{name: "i5", type: :s64, nullable: true, metadata: nil, data: [5]},
+         %Adbc.Column{name: "i6", type: :s64, nullable: true, metadata: nil, data: [6]},
+         %Adbc.Column{name: "i7", type: :s64, nullable: true, metadata: nil, data: ~c"\a"},
+         %Adbc.Column{name: "i8", type: :s64, nullable: true, metadata: nil, data: ~c"\b"},
+         %Adbc.Column{name: "i9", type: :s64, nullable: true, metadata: nil, data: ~c"\t"},
          %Adbc.Column{name: "t1", type: :string, nullable: true, metadata: nil, data: ["hello"]},
          %Adbc.Column{name: "t2", type: :string, nullable: true, metadata: nil, data: ["world"]},
          %Adbc.Column{
@@ -246,7 +246,7 @@ defmodule Adbc.SQLite.Test do
          %Adbc.Column{name: "r4", type: :f64, nullable: true, metadata: nil, data: [4.4]},
          %Adbc.Column{name: "n1", type: :f64, nullable: true, metadata: nil, data: [1.1]},
          %Adbc.Column{name: "n2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
-         %Adbc.Column{name: "n3", type: :i64, nullable: true, metadata: nil, data: [1]},
+         %Adbc.Column{name: "n3", type: :s64, nullable: true, metadata: nil, data: [1]},
          %Adbc.Column{
            name: "n4",
            type: :string,
@@ -276,9 +276,9 @@ defmodule Adbc.SQLite.Test do
                 %Adbc.Column{
                   data: [1, 2],
                   metadata: nil,
-                  name: "I64",
+                  name: "S64",
                   nullable: true,
-                  type: :i64
+                  type: :s64
                 },
                 %Adbc.Column{
                   name: "F64",
@@ -290,8 +290,8 @@ defmodule Adbc.SQLite.Test do
               ],
               num_rows: nil
             }} =
-             Connection.query(conn, "SELECT ? AS I64, ? AS F64", [
-               Adbc.Column.i64([1, 2]),
+             Connection.query(conn, "SELECT ? AS S64, ? AS F64", [
+               Adbc.Column.s64([1, 2]),
                Adbc.Column.f64([3.3, 4.4])
              ])
   end

--- a/test/adbc_test.exs
+++ b/test/adbc_test.exs
@@ -37,7 +37,7 @@ defmodule AdbcTest do
                 data: [
                   %Adbc.Column{
                     name: "num",
-                    type: :i32,
+                    type: :s32,
                     nullable: true,
                     metadata: nil,
                     data: [123]
@@ -59,7 +59,7 @@ defmodule AdbcTest do
                     data: [
                       %Adbc.Column{
                         name: "item",
-                        type: :i32,
+                        type: :s32,
                         nullable: true,
                         metadata: nil,
                         data: [1, 2, 3]
@@ -83,7 +83,7 @@ defmodule AdbcTest do
                     data: [
                       %Adbc.Column{
                         name: "item",
-                        type: :i32,
+                        type: :s32,
                         nullable: true,
                         metadata: nil,
                         data: [1, 2, 3, nil, 5]
@@ -123,7 +123,7 @@ defmodule AdbcTest do
                     data: [
                       %Adbc.Column{
                         name: "item",
-                        type: :i32,
+                        type: :s32,
                         nullable: true,
                         metadata: nil,
                         data: [1, 2, 3, nil, 5, 6, nil, 7, nil, 9]


### PR DESCRIPTION
Renamed functions for consistency with Nx and Explorer.