### PR TITLE
feat: avoid allocating ADBC inputs and outputs twice

### DIFF
--- a/c_src/adbc_arrow_array.hpp
+++ b/c_src/adbc_arrow_array.hpp
@@ -517,10 +517,10 @@ ERL_NIF_TERM get_arrow_run_end_encoded(ErlNifEnv *env, struct ArrowSchema * sche
     if (schema->children == nullptr || values->children == nullptr) {
         return erlang::nif::error(env, "invalid ArrowArray (run_end_encoded), schema->children == nullptr || values->children == nullptr");
     }
-    if (strncmp("run_ends", schema->children[0]->name, 8) != 0) {
+    if (strcmp("run_ends", schema->children[0]->name) != 0) {
         return erlang::nif::error(env, "invalid ArrowSchema (run_end_encoded), its first child is not named run_ends");
     }
-    if (strncmp("values", schema->children[1]->name, 6) != 0) {
+    if (strcmp("values", schema->children[1]->name) != 0) {
         return erlang::nif::error(env, "invalid ArrowSchema (run_end_encoded), its second child is not named values");
     }
 
@@ -580,7 +580,7 @@ ERL_NIF_TERM get_arrow_array_list_children(ErlNifEnv *env, struct ArrowSchema * 
     const uint8_t * bitmap_buffer = (const uint8_t *)values->buffers[bitmap_buffer_index];
     struct ArrowSchema * items_schema = schema->children[0];
     struct ArrowArray * items_values = values->children[0];
-    if (strncmp("item", items_schema->name, 4) != 0) {
+    if (strcmp("item", items_schema->name) != 0) {
         return erlang::nif::error(env, "invalid ArrowSchema (list), its single child is not named item");
     }
 
@@ -704,7 +704,7 @@ ERL_NIF_TERM get_arrow_array_list_view(ErlNifEnv *env, struct ArrowSchema * sche
 
     struct ArrowSchema * items_schema = schema->children[0];
     struct ArrowArray * items_values = values->children[0];
-    if (strncmp("item", items_schema->name, 4) != 0) {
+    if (strcmp("item", items_schema->name) != 0) {
         return erlang::nif::error(env, "invalid ArrowSchema (list), its single child is not named item");
     }
     if (count == -1) count = values->length;

--- a/c_src/adbc_arrow_array_stream_record.hpp
+++ b/c_src/adbc_arrow_array_stream_record.hpp
@@ -1,0 +1,12 @@
+#ifndef ADBC_ARROW_ARRAY_STREAM_RECORD_HPP
+#define ADBC_ARROW_ARRAY_STREAM_RECORD_HPP
+#pragma once
+
+#include <adbc.h>
+
+struct ArrowArrayStreamRecord {
+    struct ArrowSchema *schema;
+    struct ArrowArray *values;
+};
+
+#endif  // ADBC_ARROW_ARRAY_STREAM_RECORD_HPP

--- a/c_src/adbc_arrow_array_stream_record.hpp
+++ b/c_src/adbc_arrow_array_stream_record.hpp
@@ -7,6 +7,44 @@
 struct ArrowArrayStreamRecord {
     struct ArrowSchema *schema = nullptr;
     struct ArrowArray *values = nullptr;
+
+    /// Allocate memory for schema and values
+    /// @return 0 if success, 1 if failed
+    int allocate_schema_and_values() {
+        this->schema = (struct ArrowSchema *)enif_alloc(sizeof(struct ArrowSchema));
+        if (this->schema == nullptr) {
+            return 1;
+        }
+        memset(this->schema, 0, sizeof(struct ArrowSchema));
+
+        this->values = (struct ArrowArray *)enif_alloc(sizeof(struct ArrowArray));
+        if (this->values == nullptr) {
+            enif_free(this->schema);
+            this->schema = nullptr;
+            return 1;
+        }
+        memset(this->values, 0, sizeof(struct ArrowArray));
+        
+        return 0;
+    }
+
+    void release_schema_and_values() {
+        if (this->schema) {
+            if (this->schema->release) {
+                this->schema->release(this->schema);
+            }
+            enif_free(this->schema);
+            this->schema = nullptr;
+        }
+
+        if (this->values) {
+            if (this->values->release) {
+                this->values->release(this->values);
+            }
+            enif_free(this->values);
+            this->values = nullptr;
+        }
+    }
 };
 
 #endif  // ADBC_ARROW_ARRAY_STREAM_RECORD_HPP

--- a/c_src/adbc_arrow_array_stream_record.hpp
+++ b/c_src/adbc_arrow_array_stream_record.hpp
@@ -7,8 +7,6 @@
 struct ArrowArrayStreamRecord {
     struct ArrowSchema *schema = nullptr;
     struct ArrowArray *values = nullptr;
-    bool value_moved = false;
-    ErlNifRWLock *lock = nullptr;
 };
 
 #endif  // ADBC_ARROW_ARRAY_STREAM_RECORD_HPP

--- a/c_src/adbc_arrow_array_stream_record.hpp
+++ b/c_src/adbc_arrow_array_stream_record.hpp
@@ -5,8 +5,10 @@
 #include <adbc.h>
 
 struct ArrowArrayStreamRecord {
-    struct ArrowSchema *schema;
-    struct ArrowArray *values;
+    struct ArrowSchema *schema = nullptr;
+    struct ArrowArray *values = nullptr;
+    bool value_moved = false;
+    ErlNifRWLock *lock = nullptr;
 };
 
 #endif  // ADBC_ARROW_ARRAY_STREAM_RECORD_HPP

--- a/c_src/adbc_arrow_metadata.hpp
+++ b/c_src/adbc_arrow_metadata.hpp
@@ -1,0 +1,32 @@
+#ifndef ADBC_ARROW_METADATA_HPP
+#define ADBC_ARROW_METADATA_HPP
+#pragma once
+
+#include <stdio.h>
+#include <vector>
+#include <adbc.h>
+#include <erl_nif.h>
+#include "adbc_consts.h"
+#include "nif_utils.hpp"
+
+static int arrow_metadata_to_nif_term(ErlNifEnv *env, const char * metadata, ERL_NIF_TERM * out_metadata) {
+    std::vector<ERL_NIF_TERM> metadata_keys, metadata_values;
+    *out_metadata = kAtomNil;
+    if (metadata == nullptr) return NANOARROW_OK;
+
+    struct ArrowMetadataReader metadata_reader{};
+    struct ArrowStringView key;
+    struct ArrowStringView value;
+    NANOARROW_RETURN_NOT_OK(ArrowMetadataReaderInit(&metadata_reader, metadata));
+    while (ArrowMetadataReaderRead(&metadata_reader, &key, &value) == NANOARROW_OK) {
+        // printf("key: %.*s, value: %.*s\n", (int)key.size_bytes, key.data, (int)value.size_bytes, value.data);
+        metadata_keys.push_back(erlang::nif::make_binary(env, key.data, (size_t)key.size_bytes));
+        metadata_values.push_back(erlang::nif::make_binary(env, value.data, (size_t)value.size_bytes));
+    }
+    if (metadata_keys.size() > 0) {
+        enif_make_map_from_arrays(env, metadata_keys.data(), metadata_values.data(), (unsigned)metadata_keys.size(), out_metadata);
+    }
+    return NANOARROW_OK;
+}
+
+#endif  // ADBC_ARROW_METADATA_HPP

--- a/c_src/adbc_arrow_schema.hpp
+++ b/c_src/adbc_arrow_schema.hpp
@@ -1,0 +1,430 @@
+#ifndef ADBC_ARROW_SCHEMA_HPP
+#define ADBC_ARROW_SCHEMA_HPP
+#pragma once
+
+#include <stdio.h>
+#include <cmath>
+#include <cstdbool>
+#include <cstdint>
+#include <vector>
+#include <adbc.h>
+#include <erl_nif.h>
+#include "adbc_consts.h"
+#include "adbc_arrow_metadata.hpp"
+#include "adbc_column.hpp"
+#include "nif_utils.hpp"
+
+static int arrow_schema_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, uint64_t level, std::vector<ERL_NIF_TERM> &out_terms, ERL_NIF_TERM &value_type, ERL_NIF_TERM &metadata, ERL_NIF_TERM &error);
+
+static int get_struct_schema(ErlNifEnv *env, struct ArrowSchema * schema, uint64_t level, std::vector<ERL_NIF_TERM> &children, ERL_NIF_TERM &error) {
+    if (schema->n_children > 0 && schema->children == nullptr) {
+        error = erlang::nif::error(env, "invalid ArrowSchema, schema->children == nullptr while schema->n_children > 0");
+        return 1;
+    }
+    children.resize(schema->n_children);
+    for (int64_t child_i = 0; child_i < schema->n_children; child_i++) {
+        struct ArrowSchema * child_schema = schema->children[child_i];
+        std::vector<ERL_NIF_TERM> childrens;
+        ERL_NIF_TERM child_type;
+        ERL_NIF_TERM child_metadata;
+        if (arrow_schema_to_nif_term(env, child_schema, level + 1, childrens, child_type, child_metadata, error) != 0) {
+            return 1;
+        }
+
+        children[child_i] = make_adbc_column(env, child_schema, child_type, child_metadata);
+    }
+
+    return 0;
+}
+
+static int get_run_end_encoded_schema(ErlNifEnv *env, struct ArrowSchema * schema, uint64_t level, ERL_NIF_TERM &run_ends_schema, ERL_NIF_TERM &error) {
+    if (schema->n_children != 2) {
+        return erlang::nif::error(env, "invalid ArrowSchema (run_end_encoded), schema->n_children != 2");
+    }
+    if (schema->children == nullptr) {
+        return erlang::nif::error(env, "invalid ArrowArray (run_end_encoded), schema->children == nullptr");
+    }
+    if (strcmp("run_ends", schema->children[0]->name) != 0) {
+        return erlang::nif::error(env, "invalid ArrowSchema (run_end_encoded), its first child is not named run_ends");
+    }
+    if (strcmp("values", schema->children[1]->name) != 0) {
+        return erlang::nif::error(env, "invalid ArrowSchema (run_end_encoded), its second child is not named values");
+    }
+
+    std::vector<ERL_NIF_TERM> children(2);
+    for (int64_t child_i = 0; child_i < 2; child_i++) {
+        std::vector<ERL_NIF_TERM> childrens;
+        ERL_NIF_TERM child_type;
+        ERL_NIF_TERM child_metadata;
+        if (arrow_schema_to_nif_term(env, schema->children[child_i], level + 1, childrens, child_type, child_metadata, error) != 0) {
+            return 1;
+        }
+
+        children[child_i] = make_adbc_column(env, schema->children[child_i], child_type, child_metadata);
+    }
+
+    ERL_NIF_TERM run_ends_keys[] = { kAtomRunEnds, kAtomValues };
+    ERL_NIF_TERM run_ends_values[] = { children[0], children[1] };
+    // only fail if there are duplicated keys
+    // so we don't need to check the return value
+    enif_make_map_from_arrays(env, run_ends_keys, run_ends_values, 2, &run_ends_schema);
+    return 0;
+}
+
+static int get_map_schema(ErlNifEnv *env, struct ArrowSchema * schema, uint64_t level, ERL_NIF_TERM &map_kv_schema, ERL_NIF_TERM &error) {
+    // From https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
+    //
+    //   As specified in the Arrow columnar format, the map type has a single child type named entries,
+    //   itself a 2-child struct type of (key, value).
+    if (schema->children == nullptr) {
+        return erlang::nif::error(env, "invalid ArrowSchema (map), schema->children == nullptr");
+    }
+    if (schema->n_children != 1) {
+        return erlang::nif::error(env, "invalid ArrowSchema (map), schema->n_children != 1");
+    }
+
+    struct ArrowSchema * entries_schema = schema->children[0];
+    if (strcmp("entries", entries_schema->name) != 0) {
+        return erlang::nif::error(env, "invalid ArrowSchema (map), its single child is not named entries");
+    }
+    if (entries_schema->n_children != 2) {
+        return erlang::nif::error(env, "invalid ArrowSchema (map), its entries n_children != 2");
+    }
+
+    ERL_NIF_TERM key_schema, value_schema;
+    int kv = 0;
+    for (int64_t child_i = 0; child_i < 2; child_i++) {
+        struct ArrowSchema * entry_schema = entries_schema->children[child_i];
+        std::vector<ERL_NIF_TERM> childrens;
+        ERL_NIF_TERM child_type;
+        ERL_NIF_TERM child_metadata;
+        if (strcmp("key", entry_schema->name) == 0) {
+            if (arrow_schema_to_nif_term(env, entry_schema, level + 1, childrens, child_type, child_metadata, error) != 0) {
+                return 1;
+            }
+
+            key_schema = make_adbc_column(env, entry_schema, child_type, child_metadata);
+            kv |= 0x1;
+        } else if (strcmp("value", entry_schema->name) == 0) {
+            if (arrow_schema_to_nif_term(env, entry_schema, level + 1, childrens, child_type, child_metadata, error) != 0) {
+                return 1;
+            }
+
+            value_schema = make_adbc_column(env, entry_schema, child_type, child_metadata);
+            kv |= 0x2;
+        } else {
+            return 1;
+        }
+    }
+
+    if (kv != 3) {
+        return 1;
+    }
+
+    ERL_NIF_TERM map_kv_keys[] = { kAtomKey, kAtomValue };
+    ERL_NIF_TERM map_kv_values[] = { key_schema, value_schema };
+    // only fail if there are duplicated keys
+    // so we don't need to check the return value
+    enif_make_map_from_arrays(env, map_kv_keys, map_kv_values, 2, &map_kv_schema);
+    return 0;
+}
+
+static int get_list_element_schema(ErlNifEnv *env, struct ArrowSchema * schema, uint64_t level, ERL_NIF_TERM &element_schema, ERL_NIF_TERM &error) {
+    if (schema->children == nullptr) {
+        return erlang::nif::error(env, "invalid ArrowSchema (list), schema->children == nullptr");
+    }
+    if (schema->n_children != 1) {
+        return erlang::nif::error(env, "invalid ArrowSchema (list), schema->n_children != 1");
+    }
+
+    struct ArrowSchema * items_schema = schema->children[0];
+    if (strcmp("item", items_schema->name) != 0) {
+        return erlang::nif::error(env, "invalid ArrowSchema (list), its single child is not named item");
+    }
+
+    std::vector<ERL_NIF_TERM> childrens;
+    ERL_NIF_TERM child_type;
+    ERL_NIF_TERM child_metadata;
+    if (arrow_schema_to_nif_term(env, items_schema, level + 1, childrens, child_type, child_metadata, error) != 0) {
+        return 1;
+    }
+    element_schema = make_adbc_column(env, items_schema, child_type, child_metadata);
+    return 0;
+}
+
+static int arrow_schema_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, std::vector<ERL_NIF_TERM> &out_terms, ERL_NIF_TERM &error) {
+    ERL_NIF_TERM type_term, metadata;
+    int level = 0;
+    return arrow_schema_to_nif_term(env, schema, level, out_terms, type_term, metadata, error);
+}
+
+static int arrow_schema_to_nif_term(ErlNifEnv *env, struct ArrowSchema * schema, uint64_t level, std::vector<ERL_NIF_TERM> &out_terms, ERL_NIF_TERM &type_term, ERL_NIF_TERM &metadata, ERL_NIF_TERM &error) {
+    if (schema == nullptr) {
+        error = erlang::nif::error(env, "invalid ArrowSchema (nullptr) when invoking next");
+        return 1;
+    }
+
+    char err_msg_buf[256] = { '\0' };
+    const char* format = schema->format ? schema->format : "";
+    ERL_NIF_TERM current_term{}, children_term{};
+    size_t format_len = strlen(format);
+
+    type_term = kAtomNil;
+    std::vector<ERL_NIF_TERM> children;
+    NANOARROW_RETURN_NOT_OK(arrow_metadata_to_nif_term(env, schema->metadata, &metadata));
+
+    if (schema->dictionary != nullptr) {
+        // NANOARROW_TYPE_DICTIONARY
+        //
+        // For dictionary-encoded arrays, the ArrowSchema.format string 
+        // encodes the index type. The dictionary value type can be read 
+        // from the ArrowSchema.dictionary structure.
+        //
+        // The same holds for ArrowArray structure: while the parent 
+        // structure points to the index data, the ArrowArray.dictionary 
+        // points to the dictionary values array.
+        type_term = kAdbcColumnTypeDictionary;
+
+        std::vector<ERL_NIF_TERM> childrens;
+        ERL_NIF_TERM child_type;
+        ERL_NIF_TERM child_metadata;
+        if (arrow_schema_to_nif_term(env, schema->dictionary, level + 1, childrens, child_type, child_metadata, error) != 0) {
+            return 1;
+        }
+
+        type_term = enif_make_tuple2(env, kAdbcColumnTypeDictionary, child_type);
+        children_term = make_adbc_column(env, schema->dictionary, type_term, child_metadata);
+        return 0;
+    }
+
+    auto iter = primitiveFormatMapping.find(format);
+    if (iter != primitiveFormatMapping.end()) {
+        type_term = iter->second;
+        children_term = make_adbc_column(env, schema, type_term, metadata);
+    }
+
+    bool is_struct = false;
+    bool format_processed = true;
+    if (format_len == 1) {
+        format_processed = iter != primitiveFormatMapping.end();
+    } else if (format_len == 2) {
+        if (strncmp("+s", format, 2) == 0) {
+            // NANOARROW_TYPE_STRUCT
+            is_struct = true;
+            if (get_struct_schema(env, schema, level, children, error) != 0) {
+                return 1;
+            }
+
+            children_term = enif_make_list_from_array(env, children.data(), (unsigned)children.size());
+            type_term = enif_make_tuple2(env, kAdbcColumnTypeStruct, children_term);
+        } else if (strncmp("+r", format, 2) == 0) {
+            // NANOARROW_TYPE_RUN_END_ENCODED (maybe in nanoarrow v0.6.0)
+            // https://github.com/apache/arrow-nanoarrow/pull/507
+            ERL_NIF_TERM run_ends_schema;
+            if (get_run_end_encoded_schema(env, schema, level, run_ends_schema, error) != 0) {
+                return 1;
+            }
+
+            type_term = enif_make_tuple2(env, kAdbcColumnTypeRunEndEncoded, run_ends_schema);
+            children_term = make_adbc_column(env, schema, type_term, metadata);
+        } else if (strncmp("+m", format, 2) == 0) {
+            // NANOARROW_TYPE_MAP
+            ERL_NIF_TERM map_kv_schema;
+            if (get_map_schema(env, schema, level, map_kv_schema, error) != 0) {
+                return 1;
+            }
+
+            type_term = enif_make_tuple2(env, kAdbcColumnTypeMap, map_kv_schema);
+            children_term = make_adbc_column(env, schema, type_term, metadata);
+        } else if (strncmp("+l", format, 2) == 0) {
+            // NANOARROW_TYPE_LIST
+            ERL_NIF_TERM elem_schema;
+            if (get_list_element_schema(env, schema, level, elem_schema, error) != 0) {
+                return 1;
+            }
+
+            type_term = enif_make_tuple2(env, kAdbcColumnTypeList, elem_schema);
+            children_term = make_adbc_column(env, schema, type_term, metadata);
+        } else if (strncmp("+L", format, 2) == 0) {
+            // NANOARROW_TYPE_LARGE_LIST
+            ERL_NIF_TERM elem_schema;
+            if (get_list_element_schema(env, schema, level, elem_schema, error) != 0) {
+                return 1;
+            }
+
+            type_term = enif_make_tuple2(env, kAdbcColumnTypeLargeList, elem_schema);
+            children_term = make_adbc_column(env, schema, type_term, metadata);
+        } else {
+            format_processed = false;
+        }
+    } else if (format_len >= 3) {
+        // handle all formats that start with `t` (temporal types)
+        if (format[0] == 't') {
+            if (format_len == 3) {
+                // primitiveFormatMapping contains all temporal that have 3 characters
+                format_processed = iter != primitiveFormatMapping.end();
+            } else if (format_len >= 4 && format[1] == 's' && format[3] == ':') {
+                // according to the arrow spec:
+                //   The timezone string is appended as-is after the colon character :, 
+                //   without any quotes. If the timezone is empty, the colon : must still be included.
+                // so the format length for timestamps must be >= 4
+            
+                // possible format strings:
+                // tss: - timestamp [seconds]
+                // tsm: - timestamp [milliseconds]
+                // tsu: - timestamp [microseconds]
+                // tsn: - timestamp [nanoseconds]
+                //
+                // if there're any timezone infomation
+                // it should be in the format like `tsu:timezone`
+                // NANOARROW_TYPE_TIMESTAMP
+                ERL_NIF_TERM term_unit;
+                ERL_NIF_TERM term_timezone = kAtomNil;
+                switch (format[2]) {
+                    case 's': // seconds
+                        term_unit = kAtomSeconds;
+                        break;
+                    case 'm': // milliseconds
+                        term_unit = kAtomMilliseconds;
+                        break;
+                    case 'u': // microseconds
+                        term_unit = kAtomMicroseconds;
+                        break;
+                    case 'n': // nanoseconds
+                        term_unit = kAtomNanoseconds;
+                        break;
+                    default:
+                        format_processed = false;
+                }
+
+                if (format_processed) {
+                    if (format_len > 4 && format[3] == ':') {
+                        std::string timezone(&format[4]);
+                        term_timezone = erlang::nif::make_binary(env, timezone);
+                    }
+                    type_term = enif_make_tuple3(env, kAtomTimestamp, term_unit, term_timezone);
+                    children_term = make_adbc_column(env, schema, type_term, metadata);
+                }
+            } else {
+                format_processed = false;
+            }
+        } else {
+            if (format_len == 3 && strncmp("+vl", format, 3) == 0) {
+                // NANOARROW_TYPE_LIST(VIEW)
+                ERL_NIF_TERM elem_schema;
+                if (get_list_element_schema(env, schema, level, elem_schema, error) != 0) {
+                    return 1;
+                }
+
+                type_term = enif_make_tuple2(env, kAdbcColumnTypeListView, elem_schema);
+                children_term = make_adbc_column(env, schema, type_term, metadata);
+            } else if (format_len == 3 && strncmp("+vL", format, 3) == 0) {
+                // NANOARROW_TYPE_LARGE_LIST(VIEW)
+                ERL_NIF_TERM elem_schema;
+                if (get_list_element_schema(env, schema, level, elem_schema, error) != 0) {
+                    return 1;
+                }
+
+                type_term = enif_make_tuple2(env, kAdbcColumnTypeLargeListView, elem_schema);
+                children_term = make_adbc_column(env, schema, type_term, metadata);
+            } else if (strncmp("+w:", format, 3) == 0) {
+                // NANOARROW_TYPE_FIXED_SIZE_LIST
+                unsigned n_items = 0;
+                for (size_t i = 3; i < format_len; i++) {
+                    n_items = n_items * 10 + (format[i] - '0');
+                }
+                type_term = kAdbcColumnTypeFixedSizeList(n_items);
+                
+                ERL_NIF_TERM elem_schema;
+                if (get_list_element_schema(env, schema, level, elem_schema, error) != 0) {
+                    return 1;
+                }
+
+                type_term = enif_make_tuple2(env, type_term, elem_schema);
+                children_term = make_adbc_column(env, schema, type_term, metadata);
+            } else if (strncmp("w:", format, 2) == 0) {
+                // NANOARROW_TYPE_FIXED_SIZE_BINARY
+                size_t nbytes = 0;
+                for (size_t i = 2; i < format_len; i++) {
+                    nbytes = nbytes * 10 + (format[i] - '0');
+                }
+                type_term = kAdbcColumnTypeFixedSizeBinary(nbytes);
+                children_term = make_adbc_column(env, schema, type_term, metadata);
+            } else if (format_len > 4 && (strncmp("+ud:", format, 4) == 0)) {
+                // NANOARROW_TYPE_DENSE_UNION
+                type_term = kAdbcColumnTypeDenseUnion;
+                children_term = make_adbc_column(env, schema, type_term, metadata);
+            } else if (format_len > 4 && (strncmp("+us:", format, 4) == 0)) {
+                // NANOARROW_TYPE_SPARSE_UNION
+                type_term = kAdbcColumnTypeSparseUnion;
+                children_term = make_adbc_column(env, schema, type_term, metadata);
+            } else if (strncmp("d:", format, 2) == 0) {
+                // NANOARROW_TYPE_DECIMAL128
+                // NANOARROW_TYPE_DECIMAL256
+                //
+                // format should match `d:P,S[,N]`
+                // where P is precision, S is scale, N is bits
+                // N is optional and defaults to 128
+                int precision = 0;
+                int scale = 0;
+                int bits = 128;
+                int * d[3] = {&precision, &scale, &bits};
+                int index = 0;
+                for (size_t i = 2; i < format_len; i++) {
+                    if (format[i] == ',') {
+                        if (index < 2) {
+                            index++;
+                        } else {
+                            format_processed = false;
+                            break;
+                        }
+                        continue;
+                    }
+
+                    *d[index] = *d[index] * 10 + (format[i] - '0');
+                }
+
+                if (format_processed) {
+                    type_term = kAdbcColumnTypeDecimal(bits, precision, scale);
+                    children_term = make_adbc_column(env, schema, type_term, metadata);
+                }
+            } else {
+                format_processed = false;
+            }
+        }
+    } else {
+        format_processed = false;
+    }
+
+    if (!format_processed) {
+        snprintf(err_msg_buf, sizeof(err_msg_buf)/sizeof(err_msg_buf[0]), "not yet implemented for format: `%s`", schema->format);
+        error = erlang::nif::error(env, erlang::nif::make_binary(env, err_msg_buf));
+        return 1;
+        // printf("not implemented for format: `%s`\r\n", schema->format);
+        // printf("length: %lld\r\n", values->length);
+        // printf("null_count: %lld\r\n", values->null_count);
+        // printf("offset: %lld\r\n", values->offset);
+        // printf("n_buffers: %lld\r\n", values->n_buffers);
+        // printf("n_children: %lld\r\n", values->n_children);
+        // printf("buffers: %p\r\n", values->buffers);
+    }
+
+    out_terms.clear();
+    if (is_struct) {
+        if (level == 0) {
+            out_terms.emplace_back(make_adbc_column(env, schema, type_term, metadata, true));
+        } else {
+            out_terms.emplace_back(children_term);
+        }
+    } else {
+        if (schema->children) {
+            out_terms.emplace_back(children_term);
+        } else {
+            out_terms.emplace_back(current_term);
+        }
+    }
+
+    return 0;
+}
+
+#endif  // ADBC_ARROW_ARRAY_HPP

--- a/c_src/adbc_arrow_schema.hpp
+++ b/c_src/adbc_arrow_schema.hpp
@@ -24,7 +24,6 @@ static int get_struct_schema(ErlNifEnv *env, struct ArrowSchema * schema, struct
     children.resize(schema->n_children);
     for (int64_t child_i = 0; child_i < schema->n_children; child_i++) {
         struct ArrowSchema * child_schema = schema->children[child_i];
-        struct ArrowArray * child_array = array->children[child_i];
         std::vector<ERL_NIF_TERM> childrens;
         ERL_NIF_TERM child_type;
         ERL_NIF_TERM child_metadata;
@@ -42,6 +41,7 @@ static int get_struct_schema(ErlNifEnv *env, struct ArrowSchema * schema, struct
                 error = erlang::nif::error(env, "out of memory");
                 return 1;
             }
+            struct ArrowArray * child_array = array->children[child_i];
             ArrowSchemaDeepCopy(child_schema, record->val.schema);
             ArrowArrayMove(child_array, record->val.values);
             memset(array->children[child_i], 0, sizeof(struct ArrowArray));

--- a/c_src/adbc_column.hpp
+++ b/c_src/adbc_column.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <functional>
 #include <type_traits>
+#include <optional>
 #include <adbc.h>
 #include <erl_nif.h>
 #include <nanoarrow/nanoarrow.hpp>
@@ -97,7 +98,7 @@ int AdbcColumnNifTerm::from_term(ErlNifEnv *env, ERL_NIF_TERM adbc_column, bool 
     return 0;
 }
 
-ERL_NIF_TERM make_adbc_column(ErlNifEnv *env, struct ArrowSchema * schema, ERL_NIF_TERM type_term, ERL_NIF_TERM metadata, bool with_data_key = false) {
+ERL_NIF_TERM make_adbc_column(ErlNifEnv *env, struct ArrowSchema * schema, ERL_NIF_TERM type_term, ERL_NIF_TERM metadata, std::optional<ERL_NIF_TERM> data_ref = std::nullopt) {
     ERL_NIF_TERM nullable_term = schema->flags & ARROW_FLAG_NULLABLE ? kAtomTrue : kAtomFalse;
     ERL_NIF_TERM name_term = erlang::nif::make_binary(env, schema->name == nullptr ? "" : schema->name);
 
@@ -116,9 +117,9 @@ ERL_NIF_TERM make_adbc_column(ErlNifEnv *env, struct ArrowSchema * schema, ERL_N
         metadata,
     };
 
-    if (with_data_key) {
+    if (data_ref) {
         keys.emplace_back(kAtomDataKey);
-        values.emplace_back(kAtomNil);
+        values.emplace_back(data_ref.value());
     }
 
     ERL_NIF_TERM adbc_column;

--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -2,7 +2,10 @@
 #pragma once
 
 #include <erl_nif.h>
+#include <map>
+#include <string>
 
+static std::map<std::string, ERL_NIF_TERM> primitiveFormatMapping;
 // Atoms
 static ERL_NIF_TERM kAtomAdbcError;
 static ERL_NIF_TERM kAtomNil;

--- a/c_src/adbc_consts.h
+++ b/c_src/adbc_consts.h
@@ -5,7 +5,7 @@
 #include <map>
 #include <string>
 
-static std::map<std::string, ERL_NIF_TERM> primitiveFormatMapping;
+static std::map<std::string, std::vector<ERL_NIF_TERM>> primitiveFormatMapping;
 // Atoms
 static ERL_NIF_TERM kAtomAdbcError;
 static ERL_NIF_TERM kAtomNil;

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -497,6 +497,11 @@ static ERL_NIF_TERM adbc_arrow_array_stream_next(ErlNifEnv *env, int argc, const
     if (record == nullptr) {
         return error;
     }
+    char lock_name[] = "arrow_array_stream_record_lock";
+    record->val.lock = enif_rwlock_create(lock_name);
+    if (record->val.lock == nullptr) {
+        return erlang::nif::error(env, "out of memory: cannot create lock for ArrowArrayStreamRecord");
+    }
     record->val.values = (struct ArrowArray *)enif_alloc(sizeof(struct ArrowArray));
     if (record->val.values == nullptr) {
         return erlang::nif::error(env, "out of memory");
@@ -612,6 +617,7 @@ static ERL_NIF_TERM adbc_column_materialize(ErlNifEnv *env, int argc, const ERL_
 
     std::vector<ERL_NIF_TERM> materialized;
     ERL_NIF_TERM error{};
+    int64_t index = 0;
     for (auto& ref : data_ref) {
         if ((res = record_type::get_resource(env, ref, error)) == nullptr) {
             return error;
@@ -624,8 +630,21 @@ static ERL_NIF_TERM adbc_column_materialize(ErlNifEnv *env, int argc, const ERL_
         constexpr int level = 0;
         ERL_NIF_TERM out_type;
         ERL_NIF_TERM out_metadata;
-        if (arrow_array_to_nif_term(env, res->val.schema, res->val.values, level, out_terms, out_type, out_metadata, error) != 0) {
-            // schema and values will be release when the resource is GC'ed
+        int has_error = 0;
+        
+        enif_rwlock_rwlock(res->val.lock);
+        if (res->val.value_moved) {
+            has_error = 1;
+            char buf[256] = {'\0'};
+            snprintf(buf, sizeof(buf), "ArrowArray value at index %lld has been moved", index);
+            error = erlang::nif::error(env, buf);
+        } else {
+            if (arrow_array_to_nif_term(env, res->val.schema, res->val.values, level, out_terms, out_type, out_metadata, error) != 0) {
+                has_error = 1;
+            }
+        }
+        enif_rwlock_rwunlock(res->val.lock);
+        if (has_error) {
             return error;
         }
 
@@ -637,8 +656,9 @@ static ERL_NIF_TERM adbc_column_materialize(ErlNifEnv *env, int argc, const ERL_
         }
 
         materialized.emplace_back(ret);
+        index++;
     }
-
+    
     ERL_NIF_TERM ret = enif_make_list_from_array(env, materialized.data(), materialized.size());
     return erlang::nif::ok(env, ret);
 }
@@ -807,37 +827,17 @@ static ERL_NIF_TERM adbc_statement_bind(ErlNifEnv *env, int argc, const ERL_NIF_
     values.release = nullptr;
     schema.release = nullptr;
 
-    std::vector<ERL_NIF_TERM> refs;
-    bool is_refs = false;
-
-    if (adbc_column_to_arrow_type_struct(env, argv[1], &values, &schema, &arrow_error, refs, is_refs)) {
+    if (adbc_column_to_arrow_type_struct(env, argv[1], &values, &schema, &arrow_error)) {
         ret = erlang::nif::error(env, arrow_error.message);
         goto cleanup;
     }
 
-    if (is_refs) {
-        if (refs.size() == 1) {
-            using res_type = NifRes<struct ArrowArrayStreamRecord>;
-            res_type * record = nullptr;
-            if ((record = res_type::get_resource(env, refs[0], error)) == nullptr) {
-                return error;
-            }
-            code = AdbcStatementBind(&statement->val, record->val.values, record->val.schema, &adbc_error);
-            if (code != ADBC_STATUS_OK) {
-                return nif_error_from_adbc_error(env, &adbc_error);
-            }
-            return erlang::nif::ok(env);
-        } else {
-            return erlang::nif::error(env, "data with multiple references is not supported yet");
-        }
-    } else {
-        code = AdbcStatementBind(&statement->val, &values, &schema, &adbc_error);
-        if (code != ADBC_STATUS_OK) {
-            ret = nif_error_from_adbc_error(env, &adbc_error);
-            goto cleanup;
-        }
-        ret = erlang::nif::ok(env);
+    code = AdbcStatementBind(&statement->val, &values, &schema, &adbc_error);
+    if (code != ADBC_STATUS_OK) {
+        ret = nif_error_from_adbc_error(env, &adbc_error);
+        goto cleanup;
     }
+    ret = erlang::nif::ok(env);
 
 cleanup:
     if (values.release) values.release(&values);

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -493,6 +493,10 @@ static ERL_NIF_TERM adbc_arrow_array_stream_next(ErlNifEnv *env, int argc, const
         const char * reason = res->val.get_last_error(&res->val);
         return erlang::nif::error(env, reason ? reason : "unknown error");
     }
+    // if no error and the array is released, the stream has ended
+    if (out.release == nullptr) {
+        return kAtomEndOfSeries;
+    }
 
     if (res->private_data == nullptr) {
         res->private_data = enif_alloc(sizeof(struct ArrowSchema));
@@ -506,20 +510,13 @@ static ERL_NIF_TERM adbc_arrow_array_stream_next(ErlNifEnv *env, int argc, const
         }
     }
 
+    auto schema = (struct ArrowSchema *)res->private_data;
     std::vector<ERL_NIF_TERM> out_terms;
-    auto schema = (struct ArrowSchema*)res->private_data;
-    bool end_of_series = false;
     ERL_NIF_TERM out_type;
     ERL_NIF_TERM out_metadata;
-    if (arrow_array_to_nif_term(env, schema, &out, 0, out_terms, out_type, out_metadata, error, &end_of_series) == 1) {
+    if (arrow_array_to_nif_term(env, schema, &out, 0, out_terms, out_type, out_metadata, error) == 1) {
         if (out.release) out.release(&out);
         return error;
-    }
-    if (end_of_series) {
-        if (out.release) {
-            out.release(&out);
-        }
-        return kAtomEndOfSeries;
     }
 
     if (out_terms.size() == 1) {

--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -494,23 +494,19 @@ static ERL_NIF_TERM adbc_arrow_array_stream_next(ErlNifEnv *env, int argc, const
         return erlang::nif::error(env, reason ? reason : "unknown error");
     }
 
-    if (res->private_data != nullptr) {
-        enif_free(res->private_data);
-        res->private_data = nullptr;
-    }
-
-    res->private_data = enif_alloc(sizeof(struct ArrowSchema));
-    memset(res->private_data, 0, sizeof(struct ArrowSchema));
-    code = res->val.get_schema(&res->val, (struct ArrowSchema *)res->private_data);
-    if (code != 0) {
-        const char * reason = res->val.get_last_error(&res->val);
-        enif_free(res->private_data);
-        res->private_data = nullptr;
-        return erlang::nif::error(env, reason ? reason : "unknown error");
+    if (res->private_data == nullptr) {
+        res->private_data = enif_alloc(sizeof(struct ArrowSchema));
+        memset(res->private_data, 0, sizeof(struct ArrowSchema));
+        code = res->val.get_schema(&res->val, (struct ArrowSchema *)res->private_data);
+        if (code != 0) {
+            const char * reason = res->val.get_last_error(&res->val);
+            enif_free(res->private_data);
+            res->private_data = nullptr;
+            return erlang::nif::error(env, reason ? reason : "unknown error");
+        }
     }
 
     std::vector<ERL_NIF_TERM> out_terms;
-
     auto schema = (struct ArrowSchema*)res->private_data;
     bool end_of_series = false;
     ERL_NIF_TERM out_type;

--- a/c_src/adbc_nif_resource.hpp
+++ b/c_src/adbc_nif_resource.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <type_traits>
 #include "nif_utils.hpp"
+#include "adbc_arrow_array_stream_record.hpp"
 
 // Only for debugging:
 #include <cstdio>
@@ -133,6 +134,27 @@ static void destruct_adbc_arrow_array_stream(ErlNifEnv *env, void *args) {
     }
     enif_free(schema);
     res->private_data = nullptr;
+  }
+}
+
+static void destruct_arrow_array_stream_record(ErlNifEnv *env, void *args) {
+  auto res = (NifRes<struct ArrowArrayStreamRecord> *)args;
+  if (res->val.schema) {
+    if (res->val.schema->release) {
+      res->val.schema->release(res->val.schema);
+      res->val.schema->release = nullptr;
+    }
+    enif_free(res->val.schema);
+    res->val.schema = nullptr;
+  }
+
+  if (res->val.values) {
+    if (res->val.values->release) {
+      res->val.values->release(res->val.values);
+      res->val.values->release = nullptr;
+    }
+    enif_free(res->val.values);
+    res->val.values = nullptr;
   }
 }
 

--- a/c_src/adbc_nif_resource.hpp
+++ b/c_src/adbc_nif_resource.hpp
@@ -156,6 +156,11 @@ static void destruct_arrow_array_stream_record(ErlNifEnv *env, void *args) {
     enif_free(res->val.values);
     res->val.values = nullptr;
   }
+
+  if (res->val.lock) {
+    enif_rwlock_destroy(res->val.lock);
+    res->val.lock = nullptr;
+  }
 }
 
 #endif /* ADBC_NIF_RESOURCE_HPP */

--- a/c_src/adbc_nif_resource.hpp
+++ b/c_src/adbc_nif_resource.hpp
@@ -156,11 +156,6 @@ static void destruct_arrow_array_stream_record(ErlNifEnv *env, void *args) {
     enif_free(res->val.values);
     res->val.values = nullptr;
   }
-
-  if (res->val.lock) {
-    enif_rwlock_destroy(res->val.lock);
-    res->val.lock = nullptr;
-  }
 }
 
 #endif /* ADBC_NIF_RESOURCE_HPP */

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -5,7 +5,7 @@ defmodule Adbc.Column do
   `Adbc.Column` corresponds to a column in the table. It contains the column's name, type, and
   data. The data is a list of values of the column's data type.
   """
-  @enforce_keys [:name, :type, :nullable, :data]
+  @enforce_keys [:type]
   defstruct [:name, :type, :nullable, :metadata, :data, :length, :offset]
 
   import Bitwise
@@ -1145,6 +1145,53 @@ defmodule Adbc.Column do
   def dictionary(key = %Adbc.Column{type: index_type}, value = %Adbc.Column{}, opts \\ [])
       when index_type in [:s8, :u8, :s16, :u16, :s32, :u32, :s64, :u64] do
     column(:dictionary, %{key: key, value: value}, opts)
+  end
+
+  @doc """
+  `materialize/1` converts a column's data from reference type to regular Elixir terms.
+  """
+  @spec materialize(%Adbc.Column{data: reference() | [reference()]}) ::
+          %Adbc.Column{} | {:error, String.t()}
+  def materialize(%Adbc.Column{data: data_ref})
+      when is_reference(data_ref) or is_list(data_ref) do
+    with {:ok, results} <- Adbc.Nif.adbc_column_materialize(data_ref) do
+      merge_columns(results)
+    end
+  end
+
+  defp merge_columns([result]), do: handle_decimal(result)
+
+  defp merge_columns(chucked_results) do
+    Enum.zip_with(chucked_results, fn columns ->
+      Enum.reduce(columns, fn column, merged_column ->
+        column = handle_decimal(column)
+        %{merged_column | data: merged_column.data ++ column.data}
+      end)
+    end)
+  end
+
+  defp handle_decimal([column | rest]) do
+    [handle_decimal(column) | handle_decimal(rest)]
+  end
+
+  defp handle_decimal(%Adbc.Column{type: {:decimal, bits, _, scale}, data: decimal_data} = column) do
+    %{column | data: handle_decimal(decimal_data, bits, scale)}
+  end
+
+  defp handle_decimal(column) do
+    column
+  end
+
+  defp handle_decimal(decimal_data, bits, scale) do
+    Enum.map(decimal_data, fn data ->
+      <<decimal::signed-integer-size(bits)-little>> = data
+
+      if decimal < 0 do
+        Decimal.new(-1, -decimal, -scale)
+      else
+        Decimal.new(1, decimal, -scale)
+      end
+    end)
   end
 
   @doc """

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -1161,7 +1161,9 @@ defmodule Adbc.Column do
 
   defp merge_columns([result]), do: handle_decimal(result)
 
-  defp merge_columns(chucked_results) do
+  defp merge_columns(result) when is_map(result), do: handle_decimal(result)
+
+  defp merge_columns(chucked_results) when is_list(chucked_results) do
     Enum.zip_with(chucked_results, fn columns ->
       Enum.reduce(columns, fn column, merged_column ->
         column = handle_decimal(column)

--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -1150,7 +1150,7 @@ defmodule Adbc.Column do
   @doc """
   `materialize/1` converts a column's data from reference type to regular Elixir terms.
   """
-  @spec materialize(%Adbc.Column{data: reference() | [reference()]}) ::
+  @spec materialize(%Adbc.Column{data: reference() | [reference()] | list() | map()}) ::
           %Adbc.Column{} | {:error, String.t()}
   def materialize(%Adbc.Column{data: data_ref, type: type} = self)
       when is_reference(data_ref) or is_list(data_ref) do
@@ -1171,6 +1171,10 @@ defmodule Adbc.Column do
 
       handle_decimal(%{self | data: materialized, type: type})
     end
+  end
+
+  def materialize(%Adbc.Column{} = self) do
+    self
   end
 
   defp handle_decimal(%Adbc.Column{type: {:decimal, bits, _, scale}, data: decimal_data} = column) do

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -396,8 +396,8 @@ defmodule Adbc.Connection do
 
   defp stream_results(reference, acc, num_rows) do
     case Adbc.Nif.adbc_arrow_array_stream_next(reference) do
-      {:ok, results, _done} ->
-        stream_results(reference, [results | acc], num_rows)
+      {:ok, result, data_ref} ->
+        stream_results(reference, [%{result | data: data_ref} | acc], num_rows)
 
       :end_of_series ->
         {:ok, %Adbc.Result{data: merge_columns(Enum.reverse(acc)), num_rows: num_rows}}
@@ -407,39 +407,15 @@ defmodule Adbc.Connection do
     end
   end
 
-  defp merge_columns([result]), do: handle_decimal(result)
+  defp merge_columns([]), do: []
 
-  defp merge_columns(chucked_results) do
-    Enum.zip_with(chucked_results, fn columns ->
-      Enum.reduce(columns, fn column, merged_column ->
-        column = handle_decimal(column)
-        %{merged_column | data: merged_column.data ++ column.data}
+  defp merge_columns(results) do
+    list_of_data =
+      Enum.map(results, fn %Adbc.Column{data: data} ->
+        data
       end)
-    end)
-  end
 
-  defp handle_decimal([column | rest]) do
-    [handle_decimal(column) | handle_decimal(rest)]
-  end
-
-  defp handle_decimal(%Adbc.Column{type: {:decimal, bits, _, scale}, data: decimal_data} = column) do
-    %{column | data: handle_decimal(decimal_data, bits, scale)}
-  end
-
-  defp handle_decimal(column) do
-    column
-  end
-
-  defp handle_decimal(decimal_data, bits, scale) do
-    Enum.map(decimal_data, fn data ->
-      <<decimal::signed-integer-size(bits)-little>> = data
-
-      if decimal < 0 do
-        Decimal.new(-1, -decimal, -scale)
-      else
-        Decimal.new(1, decimal, -scale)
-      end
-    end)
+    %{Enum.at(results, 0) | data: list_of_data}
   end
 
   ## Callbacks

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -415,7 +415,7 @@ defmodule Adbc.Connection do
         data
       end)
 
-    %{Enum.at(results, 0) | data: list_of_data}
+    %{hd(results) | data: list_of_data}
   end
 
   ## Callbacks

--- a/lib/adbc_connection.ex
+++ b/lib/adbc_connection.ex
@@ -411,12 +411,7 @@ defmodule Adbc.Connection do
     Enum.zip_with(chucked_results, fn columns ->
       Enum.reduce(columns, fn column, merged_column ->
         merged_data =
-          case {is_list(merged_column.data), is_list(column.data)} do
-            {true, true} -> merged_column.data ++ column.data
-            {true, false} -> merged_column.data ++ [column.data]
-            {false, true} -> [merged_column.data] ++ column.data
-            {false, false} -> [merged_column.data] ++ [column.data]
-          end
+          List.wrap(merged_column.data) ++ List.wrap(column.data)
 
         %{merged_column | data: merged_data}
       end)

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -73,4 +73,6 @@ defmodule Adbc.Nif do
   def adbc_arrow_array_stream_next(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
 
   def adbc_arrow_array_stream_release(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
+
+  def adbc_column_materialize(_data_ref), do: :erlang.nif_error(:not_loaded)
 end

--- a/lib/adbc_result.ex
+++ b/lib/adbc_result.ex
@@ -15,6 +15,20 @@ defmodule Adbc.Result do
           num_rows: non_neg_integer() | nil,
           data: [%Adbc.Column{}]
         }
+
+  @doc """
+  `materialize/1` converts the result set's data from reference type to regular Elixir terms.
+  """
+  def materialize(%Adbc.Result{data: %Adbc.Column{} = data} = result) do
+    case Adbc.Column.materialize(data) do
+      {:error, reason} ->
+        {:error, reason}
+
+      materialized ->
+        %{result | data: materialized}
+    end
+  end
+
   @doc """
   Returns a map of columns as a result.
   """

--- a/lib/adbc_result.ex
+++ b/lib/adbc_result.ex
@@ -19,7 +19,8 @@ defmodule Adbc.Result do
   @doc """
   `materialize/1` converts the result set's data from reference type to regular Elixir terms.
   """
-  @spec materialize(%Adbc.Result{} | {:ok, %Adbc.Result{}} | {:error, String.t()}) :: %Adbc.Result{} | {:ok, %Adbc.Result{}} | {:error, String.t()}
+  @spec materialize(%Adbc.Result{} | {:ok, %Adbc.Result{}} | {:error, String.t()}) ::
+          %Adbc.Result{} | {:ok, %Adbc.Result{}} | {:error, String.t()}
   def materialize(%Adbc.Result{data: data} = result) when is_list(data) do
     %{result | data: Enum.map(data, &Adbc.Column.materialize/1)}
   end

--- a/lib/adbc_result.ex
+++ b/lib/adbc_result.ex
@@ -19,14 +19,8 @@ defmodule Adbc.Result do
   @doc """
   `materialize/1` converts the result set's data from reference type to regular Elixir terms.
   """
-  def materialize(%Adbc.Result{data: %Adbc.Column{} = data} = result) do
-    case Adbc.Column.materialize(data) do
-      {:error, reason} ->
-        {:error, reason}
-
-      materialized ->
-        %{result | data: materialized}
-    end
+  def materialize(%Adbc.Result{data: data} = result) when is_list(data) do
+    %{result | data: Enum.map(data, &Adbc.Column.materialize/1)}
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,9 @@ defmodule Adbc.MixProject do
       docs: docs(),
       description: "Apache Arrow ADBC bindings for Elixir",
       compilers: [:elixir_make] ++ Mix.compilers(),
+      make_env: %{
+        "CMAKE_BUILD_TYPE" => (String.ends_with?(@version, "-dev") && "Debug") || "Release"
+      },
       make_precompiler: {:nif, CCPrecompiler},
       make_precompiler_url: "#{@github_url}/releases/download/v#{@version}/@{artefact_filename}",
       make_precompiler_filename: "adbc_nif",

--- a/mix.exs
+++ b/mix.exs
@@ -15,9 +15,6 @@ defmodule Adbc.MixProject do
       docs: docs(),
       description: "Apache Arrow ADBC bindings for Elixir",
       compilers: [:elixir_make] ++ Mix.compilers(),
-      make_env: %{
-        "CMAKE_BUILD_TYPE" => (String.ends_with?(@version, "-dev") && "Debug") || "Release"
-      },
       make_precompiler: {:nif, CCPrecompiler},
       make_precompiler_url: "#{@github_url}/releases/download/v#{@version}/@{artefact_filename}",
       make_precompiler_filename: "adbc_nif",

--- a/test/adbc_column_test.exs
+++ b/test/adbc_column_test.exs
@@ -276,7 +276,7 @@ defmodule Adbc.Column.Test do
                nullable: true,
                metadata: nil,
                data: [
-                 inner1 = %Adbc.Column{
+                 %Adbc.Column{
                    name: "item",
                    type: :s32,
                    nullable: false,

--- a/test/adbc_column_test.exs
+++ b/test/adbc_column_test.exs
@@ -252,7 +252,7 @@ defmodule Adbc.Column.Test do
   describe "list view" do
     test "nested list view to list" do
       list_view = %Adbc.Column{
-        name: nil,
+        name: "my_array",
         type: :list_view,
         nullable: true,
         metadata: nil,
@@ -271,7 +271,7 @@ defmodule Adbc.Column.Test do
       }
 
       assert %Adbc.Column{
-               name: nil,
+               name: "my_array",
                type: :list,
                nullable: true,
                metadata: nil,
@@ -308,6 +308,9 @@ defmodule Adbc.Column.Test do
                ]
              } = Adbc.Column.to_list(list_view)
 
+      assert %{"my_array" => [[12, -7, 25], nil, [0, -127, 127, 50], [], ~c"2\f"]} ==
+               Adbc.Result.to_map(%Adbc.Result{data: [list_view]})
+
       nested_list_view = %Adbc.Column{
         name: nil,
         type: :list_view,
@@ -327,7 +330,7 @@ defmodule Adbc.Column.Test do
                  # => [inner3, inner4]
                  %Adbc.Column{
                    metadata: nil,
-                   name: nil,
+                   name: "my_array",
                    nullable: true,
                    type: :list,
                    data: [
@@ -354,11 +357,11 @@ defmodule Adbc.Column.Test do
                  # => inner1
                  %Adbc.Column{
                    metadata: nil,
-                   name: nil,
+                   name: "my_array",
                    nullable: true,
                    type: :list,
                    data: [
-                     ^inner1 = %Adbc.Column{
+                     %Adbc.Column{
                        name: "item",
                        type: :s32,
                        nullable: false,
@@ -369,7 +372,13 @@ defmodule Adbc.Column.Test do
                  },
                  # offsets=0, sizes=0
                  # => []
-                 %Adbc.Column{data: [], metadata: nil, name: nil, nullable: true, type: :list},
+                 %Adbc.Column{
+                   data: [],
+                   metadata: nil,
+                   name: "my_array",
+                   nullable: true,
+                   type: :list
+                 },
                  # offsets=3, sizes=2
                  # => [inner4, inner5]
                  %Adbc.Column{
@@ -390,7 +399,7 @@ defmodule Adbc.Column.Test do
                      }
                    ],
                    metadata: nil,
-                   name: nil,
+                   name: "my_array",
                    nullable: true,
                    type: :list
                  }

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -47,28 +47,20 @@ defmodule Adbc.Connection.Test do
       assert {
                :ok,
                results = %Adbc.Result{
-                 data: %Adbc.Column{
-                   data: _,
-                   name: "",
-                   type:
-                     {:struct,
-                      [
-                        %Adbc.Column{
-                          name: "info_name",
-                          type: :u32,
-                          metadata: nil,
-                          nullable: false
-                        },
-                        %Adbc.Column{
-                          name: "info_value",
-                          type: :dense_union,
-                          metadata: nil,
-                          nullable: true
-                        }
-                      ]},
-                   metadata: nil,
-                   nullable: true
-                 },
+                 data: [
+                   %Adbc.Column{
+                     name: "info_name",
+                     type: :u32,
+                     metadata: nil,
+                     nullable: false
+                   },
+                   %Adbc.Column{
+                     name: "info_value",
+                     type: :dense_union,
+                     metadata: nil,
+                     nullable: true
+                   }
+                 ],
                  num_rows: nil
                }
              } = Connection.get_info(conn)
@@ -108,28 +100,20 @@ defmodule Adbc.Connection.Test do
 
       assert {:ok,
               results = %Adbc.Result{
-                data: %Adbc.Column{
-                  data: _,
-                  name: "",
-                  type:
-                    {:struct,
-                     [
-                       %Adbc.Column{
-                         name: "info_name",
-                         type: :u32,
-                         metadata: nil,
-                         nullable: false
-                       },
-                       %Adbc.Column{
-                         name: "info_value",
-                         type: :dense_union,
-                         metadata: nil,
-                         nullable: true
-                       }
-                     ]},
-                  metadata: nil,
-                  nullable: true
-                },
+                data: [
+                  %Adbc.Column{
+                    name: "info_name",
+                    type: :u32,
+                    metadata: nil,
+                    nullable: false
+                  },
+                  %Adbc.Column{
+                    name: "info_value",
+                    type: :dense_union,
+                    metadata: nil,
+                    nullable: true
+                  }
+                ],
                 num_rows: nil
               }} = Connection.get_info(conn, [0])
 
@@ -211,22 +195,14 @@ defmodule Adbc.Connection.Test do
       assert {:ok,
               results = %Adbc.Result{
                 num_rows: nil,
-                data: %Adbc.Column{
-                  data: _,
-                  name: "",
-                  type:
-                    {:struct,
-                     [
-                       %Adbc.Column{
-                         name: "table_type",
-                         type: :string,
-                         metadata: nil,
-                         nullable: false
-                       }
-                     ]},
-                  metadata: nil,
-                  nullable: true
-                }
+                data: [
+                  %Adbc.Column{
+                    name: "table_type",
+                    type: :string,
+                    metadata: nil,
+                    nullable: false
+                  }
+                ]
               }} = Connection.get_table_types(conn)
 
       assert results =
@@ -252,22 +228,14 @@ defmodule Adbc.Connection.Test do
 
       assert {:ok,
               results = %Adbc.Result{
-                data: %Adbc.Column{
-                  data: _,
-                  name: "",
-                  type:
-                    {:struct,
-                     [
-                       %Adbc.Column{
-                         name: "num",
-                         type: :s64,
-                         metadata: nil,
-                         nullable: true
-                       }
-                     ]},
-                  metadata: nil,
-                  nullable: true
-                },
+                data: [
+                  %Adbc.Column{
+                    name: "num",
+                    type: :s64,
+                    metadata: nil,
+                    nullable: true
+                  }
+                ],
                 num_rows: nil
               }} = Connection.query(conn, "SELECT 123 as num")
 
@@ -285,28 +253,20 @@ defmodule Adbc.Connection.Test do
 
       assert {:ok,
               results = %Adbc.Result{
-                data: %Adbc.Column{
-                  data: _,
-                  name: "",
-                  type:
-                    {:struct,
-                     [
-                       %Adbc.Column{
-                         name: "num",
-                         type: :s64,
-                         metadata: nil,
-                         nullable: true
-                       },
-                       %Adbc.Column{
-                         name: "bool",
-                         type: :s64,
-                         metadata: nil,
-                         nullable: true
-                       }
-                     ]},
-                  metadata: nil,
-                  nullable: true
-                },
+                data: [
+                  %Adbc.Column{
+                    name: "num",
+                    type: :s64,
+                    metadata: nil,
+                    nullable: true
+                  },
+                  %Adbc.Column{
+                    name: "bool",
+                    type: :s64,
+                    metadata: nil,
+                    nullable: true
+                  }
+                ],
                 num_rows: nil
               }} = Connection.query(conn, "SELECT 123 as num, true as bool")
 
@@ -335,22 +295,14 @@ defmodule Adbc.Connection.Test do
 
       assert {:ok,
               results = %Adbc.Result{
-                data: %Adbc.Column{
-                  data: _,
-                  name: "",
-                  type:
-                    {:struct,
-                     [
-                       %Adbc.Column{
-                         name: "num",
-                         type: :s64,
-                         metadata: nil,
-                         nullable: true
-                       }
-                     ]},
-                  metadata: nil,
-                  nullable: true
-                },
+                data: [
+                  %Adbc.Column{
+                    name: "num",
+                    type: :s64,
+                    metadata: nil,
+                    nullable: true
+                  }
+                ],
                 num_rows: nil
               }} = Connection.query(conn, "SELECT 123 + ? as num", [456])
 
@@ -370,7 +322,7 @@ defmodule Adbc.Connection.Test do
     test "use reference type results as query parameter", %{db: db} do
       conn = start_supervised!({Connection, database: db})
 
-      assert {:ok, results = %Adbc.Result{data: column}} =
+      assert {:ok, results = %Adbc.Result{data: [column]}} =
                Connection.query(conn, "SELECT 123 + ? as num", [456])
 
       assert %Adbc.Result{
@@ -434,22 +386,14 @@ defmodule Adbc.Connection.Test do
 
       assert {:ok,
               results = %Adbc.Result{
-                data: %Adbc.Column{
-                  data: _,
-                  name: "",
-                  type:
-                    {:struct,
-                     [
-                       %Adbc.Column{
-                         name: "num",
-                         type: :s64,
-                         metadata: nil,
-                         nullable: true
-                       }
-                     ]},
-                  metadata: nil,
-                  nullable: true
-                },
+                data: [
+                  %Adbc.Column{
+                    name: "num",
+                    type: :s64,
+                    metadata: nil,
+                    nullable: true
+                  }
+                ],
                 num_rows: nil
               }} = Connection.query(conn, ref, [456])
 
@@ -473,22 +417,14 @@ defmodule Adbc.Connection.Test do
 
       assert {:ok,
               results = %Adbc.Result{
-                data: %Adbc.Column{
-                  data: _,
-                  name: "",
-                  type:
-                    {:struct,
-                     [
-                       %Adbc.Column{
-                         name: "num",
-                         type: :s64,
-                         metadata: nil,
-                         nullable: true
-                       }
-                     ]},
-                  metadata: nil,
-                  nullable: true
-                },
+                data: [
+                  %Adbc.Column{
+                    name: "num",
+                    type: :s64,
+                    metadata: nil,
+                    nullable: true
+                  }
+                ],
                 num_rows: nil
               }} = Connection.query(conn, ref_a, [456])
 
@@ -506,22 +442,14 @@ defmodule Adbc.Connection.Test do
 
       assert {:ok,
               results = %Adbc.Result{
-                data: %Adbc.Column{
-                  data: _,
-                  name: "",
-                  type:
-                    {:struct,
-                     [
-                       %Adbc.Column{
-                         name: "num",
-                         type: :s64,
-                         metadata: nil,
-                         nullable: true
-                       }
-                     ]},
-                  metadata: nil,
-                  nullable: true
-                },
+                data: [
+                  %Adbc.Column{
+                    name: "num",
+                    type: :s64,
+                    metadata: nil,
+                    nullable: true
+                  }
+                ],
                 num_rows: nil
               }} = Connection.query(conn, ref_b, [456])
 
@@ -545,22 +473,14 @@ defmodule Adbc.Connection.Test do
 
       assert results =
                %Adbc.Result{
-                 data: %Adbc.Column{
-                   data: _,
-                   name: "",
-                   type:
-                     {:struct,
-                      [
-                        %Adbc.Column{
-                          name: "num",
-                          type: :s64,
-                          metadata: nil,
-                          nullable: true
-                        }
-                      ]},
-                   metadata: nil,
-                   nullable: true
-                 },
+                 data: [
+                   %Adbc.Column{
+                     name: "num",
+                     type: :s64,
+                     metadata: nil,
+                     nullable: true
+                   }
+                 ],
                  num_rows: nil
                } = Connection.query!(conn, "SELECT 123 as num")
 
@@ -578,28 +498,20 @@ defmodule Adbc.Connection.Test do
 
       assert results =
                %Adbc.Result{
-                 data: %Adbc.Column{
-                   data: _,
-                   name: "",
-                   type:
-                     {:struct,
-                      [
-                        %Adbc.Column{
-                          name: "num",
-                          type: :s64,
-                          metadata: nil,
-                          nullable: true
-                        },
-                        %Adbc.Column{
-                          name: "bool",
-                          type: :s64,
-                          metadata: nil,
-                          nullable: true
-                        }
-                      ]},
-                   metadata: nil,
-                   nullable: true
-                 },
+                 data: [
+                   %Adbc.Column{
+                     name: "num",
+                     type: :s64,
+                     metadata: nil,
+                     nullable: true
+                   },
+                   %Adbc.Column{
+                     name: "bool",
+                     type: :s64,
+                     metadata: nil,
+                     nullable: true
+                   }
+                 ],
                  num_rows: nil
                } = Connection.query!(conn, "SELECT 123 as num, true as bool")
 
@@ -622,22 +534,14 @@ defmodule Adbc.Connection.Test do
 
       assert results =
                %Adbc.Result{
-                 data: %Adbc.Column{
-                   data: _,
-                   name: "",
-                   type:
-                     {:struct,
-                      [
-                        %Adbc.Column{
-                          name: "num",
-                          type: :s64,
-                          metadata: nil,
-                          nullable: true
-                        }
-                      ]},
-                   metadata: nil,
-                   nullable: true
-                 },
+                 data: [
+                   %Adbc.Column{
+                     name: "num",
+                     type: :s64,
+                     metadata: nil,
+                     nullable: true
+                   }
+                 ],
                  num_rows: nil
                } = Connection.query!(conn, "SELECT 123 + ? as num", [456])
 
@@ -669,28 +573,20 @@ defmodule Adbc.Connection.Test do
 
       assert results =
                %Adbc.Result{
-                 data: %Adbc.Column{
-                   data: _,
-                   name: "",
-                   type:
-                     {:struct,
-                      [
-                        %Adbc.Column{
-                          name: "num",
-                          type: :s64,
-                          metadata: nil,
-                          nullable: true
-                        },
-                        %Adbc.Column{
-                          name: "bool",
-                          type: :s64,
-                          metadata: nil,
-                          nullable: true
-                        }
-                      ]},
-                   metadata: nil,
-                   nullable: true
-                 },
+                 data: [
+                   %Adbc.Column{
+                     name: "num",
+                     type: :s64,
+                     metadata: nil,
+                     nullable: true
+                   },
+                   %Adbc.Column{
+                     name: "bool",
+                     type: :s64,
+                     metadata: nil,
+                     nullable: true
+                   }
+                 ],
                  num_rows: nil
                } =
                Connection.query!(conn, "SELECT 123 as num, true as bool", [],
@@ -716,22 +612,14 @@ defmodule Adbc.Connection.Test do
 
       assert results =
                %Adbc.Result{
-                 data: %Adbc.Column{
-                   data: _,
-                   name: "",
-                   type:
-                     {:struct,
-                      [
-                        %Adbc.Column{
-                          name: "num",
-                          type: :s64,
-                          metadata: nil,
-                          nullable: true
-                        }
-                      ]},
-                   metadata: nil,
-                   nullable: true
-                 },
+                 data: [
+                   %Adbc.Column{
+                     name: "num",
+                     type: :s64,
+                     metadata: nil,
+                     nullable: true
+                   }
+                 ],
                  num_rows: nil
                } =
                Connection.query!(conn, "SELECT 123 + ? as num", [456],

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -402,6 +402,24 @@ defmodule Adbc.Connection.Test do
                  }
                ]
              } = Adbc.Result.materialize(results)
+
+      assert {:ok,
+              results = %Adbc.Result{
+                data: _,
+                num_rows: nil
+              }} = Connection.query(conn, "SELECT ? + ? as num", [column, column])
+
+      assert %Adbc.Result{
+               data: [
+                 %Adbc.Column{
+                   name: "num",
+                   type: :s64,
+                   nullable: true,
+                   metadata: nil,
+                   data: [1158]
+                 }
+               ]
+             } = Adbc.Result.materialize(results)
     end
 
     test "fails on invalid query", %{db: db} do

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -367,30 +367,11 @@ defmodule Adbc.Connection.Test do
              } = Adbc.Result.materialize(results)
     end
 
-    test "use reference type results as query parameters", %{db: db} do
+    test "use reference type results as query parameter", %{db: db} do
       conn = start_supervised!({Connection, database: db})
 
-      assert {:ok,
-              results = %Adbc.Result{
-                data:
-                  column = %Adbc.Column{
-                    data: _,
-                    name: "",
-                    type:
-                      {:struct,
-                       [
-                         %Adbc.Column{
-                           name: "num",
-                           type: :s64,
-                           metadata: nil,
-                           nullable: true
-                         }
-                       ]},
-                    metadata: nil,
-                    nullable: true
-                  },
-                num_rows: nil
-              }} = Connection.query(conn, "SELECT 123 + ? as num", [456])
+      assert {:ok, results = %Adbc.Result{data: column}} =
+               Connection.query(conn, "SELECT 123 + ? as num", [456])
 
       assert %Adbc.Result{
                data: [
@@ -406,9 +387,9 @@ defmodule Adbc.Connection.Test do
 
       assert {:ok,
               results = %Adbc.Result{
-                data: column,
+                data: _,
                 num_rows: nil
-              }} = Connection.query(conn, "SELECT 123 + ? as num", [column])
+              }} = Connection.query(conn, "SELECT ? + ? as num", [421, column])
 
       assert %Adbc.Result{
                data: [
@@ -417,7 +398,7 @@ defmodule Adbc.Connection.Test do
                    type: :s64,
                    nullable: true,
                    metadata: nil,
-                   data: [702]
+                   data: [1000]
                  }
                ]
              } = Adbc.Result.materialize(results)

--- a/test/adbc_connection_test.exs
+++ b/test/adbc_connection_test.exs
@@ -120,7 +120,28 @@ defmodule Adbc.Connection.Test do
   describe "get_objects" do
     test "get all objects from a connection", %{db: db} do
       conn = start_supervised!({Connection, database: db})
-      {:ok, results = %Adbc.Result{num_rows: nil, data: []}} = Connection.get_objects(conn, 0)
+
+      {:ok,
+       %Adbc.Result{
+         num_rows: nil,
+         data: [
+           %Adbc.Column{
+             data: [],
+             name: "catalog_name",
+             type: :string,
+             metadata: nil,
+             nullable: true
+           },
+           %Adbc.Column{
+             data: [],
+             name: "catalog_db_schemas",
+             type: :list,
+             metadata: nil,
+             nullable: true
+           }
+         ]
+       }} = Connection.get_objects(conn, 0)
+
       assert %{} == Adbc.Result.to_map(results)
     end
   end

--- a/test/adbc_sqlite_test.exs
+++ b/test/adbc_sqlite_test.exs
@@ -76,60 +76,111 @@ defmodule Adbc.SQLite.Test do
       ]
     )
 
-    {:ok,
-     list_result = %Adbc.Result{
-       data: [
-         %Adbc.Column{name: "i1", type: :s64, nullable: true, metadata: nil, data: [1]},
-         %Adbc.Column{name: "i2", type: :s64, nullable: true, metadata: nil, data: [2]},
-         %Adbc.Column{name: "i3", type: :s64, nullable: true, metadata: nil, data: [3]},
-         %Adbc.Column{name: "i4", type: :s64, nullable: true, metadata: nil, data: [4]},
-         %Adbc.Column{name: "i5", type: :s64, nullable: true, metadata: nil, data: [5]},
-         %Adbc.Column{name: "i6", type: :s64, nullable: true, metadata: nil, data: [6]},
-         %Adbc.Column{name: "i7", type: :s64, nullable: true, metadata: nil, data: ~c"\a"},
-         %Adbc.Column{name: "i8", type: :s64, nullable: true, metadata: nil, data: ~c"\b"},
-         %Adbc.Column{name: "i9", type: :s64, nullable: true, metadata: nil, data: ~c"\t"},
-         %Adbc.Column{name: "t1", type: :string, nullable: true, metadata: nil, data: ["hello"]},
-         %Adbc.Column{name: "t2", type: :string, nullable: true, metadata: nil, data: ["world"]},
-         %Adbc.Column{
-           name: "t3",
-           type: :string,
-           nullable: true,
-           metadata: nil,
-           data: ["goodbye"]
-         },
-         %Adbc.Column{name: "t4", type: :string, nullable: true, metadata: nil, data: ["world"]},
-         %Adbc.Column{name: "t5", type: :string, nullable: true, metadata: nil, data: ["foo"]},
-         %Adbc.Column{name: "t6", type: :string, nullable: true, metadata: nil, data: ["bar"]},
-         %Adbc.Column{
-           name: "b1",
-           type: :string,
-           nullable: true,
-           metadata: nil,
-           data: [<<100, 97, 116, 97, 1, 2>>]
-         },
-         %Adbc.Column{name: "r1", type: :f64, nullable: true, metadata: nil, data: [1.1]},
-         %Adbc.Column{name: "r2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
-         %Adbc.Column{name: "r3", type: :f64, nullable: true, metadata: nil, data: [3.3]},
-         %Adbc.Column{name: "r4", type: :f64, nullable: true, metadata: nil, data: [4.4]},
-         %Adbc.Column{name: "n1", type: :f64, nullable: true, metadata: nil, data: [1.1]},
-         %Adbc.Column{name: "n2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
-         %Adbc.Column{name: "n3", type: :s64, nullable: true, metadata: nil, data: [1]},
-         %Adbc.Column{
-           name: "n4",
-           type: :string,
-           nullable: true,
-           metadata: nil,
-           data: ["2021-01-01"]
-         },
-         %Adbc.Column{
-           name: "n5",
-           type: :string,
-           nullable: true,
-           metadata: nil,
-           data: ["2021-01-01 00:00:00"]
-         }
-       ]
-     }} = Adbc.Connection.query(conn, "SELECT * FROM test")
+    assert {:ok, results = %Adbc.Result{num_rows: nil, data: %{data: _, name: ""}}} =
+             Connection.query(conn, "SELECT * FROM test")
+
+    assert list_result =
+             %Adbc.Result{
+               data: [
+                 %Adbc.Column{name: "i1", type: :s64, nullable: true, metadata: nil, data: [1]},
+                 %Adbc.Column{name: "i2", type: :s64, nullable: true, metadata: nil, data: [2]},
+                 %Adbc.Column{name: "i3", type: :s64, nullable: true, metadata: nil, data: [3]},
+                 %Adbc.Column{name: "i4", type: :s64, nullable: true, metadata: nil, data: [4]},
+                 %Adbc.Column{name: "i5", type: :s64, nullable: true, metadata: nil, data: [5]},
+                 %Adbc.Column{name: "i6", type: :s64, nullable: true, metadata: nil, data: [6]},
+                 %Adbc.Column{
+                   name: "i7",
+                   type: :s64,
+                   nullable: true,
+                   metadata: nil,
+                   data: ~c"\a"
+                 },
+                 %Adbc.Column{
+                   name: "i8",
+                   type: :s64,
+                   nullable: true,
+                   metadata: nil,
+                   data: ~c"\b"
+                 },
+                 %Adbc.Column{
+                   name: "i9",
+                   type: :s64,
+                   nullable: true,
+                   metadata: nil,
+                   data: ~c"\t"
+                 },
+                 %Adbc.Column{
+                   name: "t1",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: ["hello"]
+                 },
+                 %Adbc.Column{
+                   name: "t2",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: ["world"]
+                 },
+                 %Adbc.Column{
+                   name: "t3",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: ["goodbye"]
+                 },
+                 %Adbc.Column{
+                   name: "t4",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: ["world"]
+                 },
+                 %Adbc.Column{
+                   name: "t5",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: ["foo"]
+                 },
+                 %Adbc.Column{
+                   name: "t6",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: ["bar"]
+                 },
+                 %Adbc.Column{
+                   name: "b1",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: [<<100, 97, 116, 97, 1, 2>>]
+                 },
+                 %Adbc.Column{name: "r1", type: :f64, nullable: true, metadata: nil, data: [1.1]},
+                 %Adbc.Column{name: "r2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
+                 %Adbc.Column{name: "r3", type: :f64, nullable: true, metadata: nil, data: [3.3]},
+                 %Adbc.Column{name: "r4", type: :f64, nullable: true, metadata: nil, data: [4.4]},
+                 %Adbc.Column{name: "n1", type: :f64, nullable: true, metadata: nil, data: [1.1]},
+                 %Adbc.Column{name: "n2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
+                 %Adbc.Column{name: "n3", type: :s64, nullable: true, metadata: nil, data: [1]},
+                 %Adbc.Column{
+                   name: "n4",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: ["2021-01-01"]
+                 },
+                 %Adbc.Column{
+                   name: "n5",
+                   type: :string,
+                   nullable: true,
+                   metadata: nil,
+                   data: ["2021-01-01 00:00:00"]
+                 }
+               ]
+             } = Adbc.Result.materialize(results)
 
     %{
       "b1" => [<<100, 97, 116, 97, 1, 2>>],
@@ -196,73 +247,105 @@ defmodule Adbc.SQLite.Test do
       ]
     )
 
-    {:ok,
-     %Adbc.Result{
-       num_rows: nil,
-       data: [
-         %Adbc.Column{name: "i1", type: :s64, nullable: true, metadata: nil, data: [1]},
-         %Adbc.Column{name: "i2", type: :s64, nullable: true, metadata: nil, data: [2]},
-         %Adbc.Column{name: "i3", type: :s64, nullable: true, metadata: nil, data: [3]},
-         %Adbc.Column{name: "i4", type: :s64, nullable: true, metadata: nil, data: [4]},
-         %Adbc.Column{name: "i5", type: :s64, nullable: true, metadata: nil, data: [5]},
-         %Adbc.Column{name: "i6", type: :s64, nullable: true, metadata: nil, data: [6]},
-         %Adbc.Column{name: "i7", type: :s64, nullable: true, metadata: nil, data: ~c"\a"},
-         %Adbc.Column{name: "i8", type: :s64, nullable: true, metadata: nil, data: ~c"\b"},
-         %Adbc.Column{name: "i9", type: :s64, nullable: true, metadata: nil, data: ~c"\t"},
-         %Adbc.Column{name: "t1", type: :string, nullable: true, metadata: nil, data: ["hello"]},
-         %Adbc.Column{name: "t2", type: :string, nullable: true, metadata: nil, data: ["world"]},
-         %Adbc.Column{
-           name: "t3",
-           type: :string,
-           nullable: true,
-           metadata: nil,
-           data: ["goodbye"]
-         },
-         %Adbc.Column{name: "t4", type: :string, nullable: true, metadata: nil, data: ["world"]},
-         %Adbc.Column{name: "t5", type: :string, nullable: true, metadata: nil, data: ["foo"]},
-         %Adbc.Column{name: "t6", type: :string, nullable: true, metadata: nil, data: ["bar"]},
-         %Adbc.Column{
-           name: "b1",
-           type: :binary,
-           nullable: true,
-           metadata: nil,
-           data: [<<100, 97, 116, 97, 1, 2>>]
-         },
-         %Adbc.Column{
-           name: "r1",
-           type: :f64,
-           nullable: true,
-           metadata: nil,
-           data: [r1]
-         },
-         %Adbc.Column{name: "r2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
-         %Adbc.Column{
-           name: "r3",
-           type: :f64,
-           nullable: true,
-           metadata: nil,
-           data: [r3]
-         },
-         %Adbc.Column{name: "r4", type: :f64, nullable: true, metadata: nil, data: [4.4]},
-         %Adbc.Column{name: "n1", type: :f64, nullable: true, metadata: nil, data: [1.1]},
-         %Adbc.Column{name: "n2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
-         %Adbc.Column{name: "n3", type: :s64, nullable: true, metadata: nil, data: [1]},
-         %Adbc.Column{
-           name: "n4",
-           type: :string,
-           nullable: true,
-           metadata: nil,
-           data: ["2021-01-01"]
-         },
-         %Adbc.Column{
-           name: "n5",
-           type: :string,
-           nullable: true,
-           metadata: nil,
-           data: ["2021-01-01 00:00:00"]
-         }
-       ]
-     }} = Connection.query(conn, "SELECT * FROM test")
+    assert {:ok, results = %Adbc.Result{num_rows: nil, data: %{data: _, name: ""}}} =
+             Connection.query(conn, "SELECT * FROM test")
+
+    assert %Adbc.Result{
+             num_rows: nil,
+             data: [
+               %Adbc.Column{name: "i1", type: :s64, nullable: true, metadata: nil, data: [1]},
+               %Adbc.Column{name: "i2", type: :s64, nullable: true, metadata: nil, data: [2]},
+               %Adbc.Column{name: "i3", type: :s64, nullable: true, metadata: nil, data: [3]},
+               %Adbc.Column{name: "i4", type: :s64, nullable: true, metadata: nil, data: [4]},
+               %Adbc.Column{name: "i5", type: :s64, nullable: true, metadata: nil, data: [5]},
+               %Adbc.Column{name: "i6", type: :s64, nullable: true, metadata: nil, data: [6]},
+               %Adbc.Column{name: "i7", type: :s64, nullable: true, metadata: nil, data: ~c"\a"},
+               %Adbc.Column{name: "i8", type: :s64, nullable: true, metadata: nil, data: ~c"\b"},
+               %Adbc.Column{name: "i9", type: :s64, nullable: true, metadata: nil, data: ~c"\t"},
+               %Adbc.Column{
+                 name: "t1",
+                 type: :string,
+                 nullable: true,
+                 metadata: nil,
+                 data: ["hello"]
+               },
+               %Adbc.Column{
+                 name: "t2",
+                 type: :string,
+                 nullable: true,
+                 metadata: nil,
+                 data: ["world"]
+               },
+               %Adbc.Column{
+                 name: "t3",
+                 type: :string,
+                 nullable: true,
+                 metadata: nil,
+                 data: ["goodbye"]
+               },
+               %Adbc.Column{
+                 name: "t4",
+                 type: :string,
+                 nullable: true,
+                 metadata: nil,
+                 data: ["world"]
+               },
+               %Adbc.Column{
+                 name: "t5",
+                 type: :string,
+                 nullable: true,
+                 metadata: nil,
+                 data: ["foo"]
+               },
+               %Adbc.Column{
+                 name: "t6",
+                 type: :string,
+                 nullable: true,
+                 metadata: nil,
+                 data: ["bar"]
+               },
+               %Adbc.Column{
+                 name: "b1",
+                 type: :binary,
+                 nullable: true,
+                 metadata: nil,
+                 data: [<<100, 97, 116, 97, 1, 2>>]
+               },
+               %Adbc.Column{
+                 name: "r1",
+                 type: :f64,
+                 nullable: true,
+                 metadata: nil,
+                 data: [r1]
+               },
+               %Adbc.Column{name: "r2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
+               %Adbc.Column{
+                 name: "r3",
+                 type: :f64,
+                 nullable: true,
+                 metadata: nil,
+                 data: [r3]
+               },
+               %Adbc.Column{name: "r4", type: :f64, nullable: true, metadata: nil, data: [4.4]},
+               %Adbc.Column{name: "n1", type: :f64, nullable: true, metadata: nil, data: [1.1]},
+               %Adbc.Column{name: "n2", type: :f64, nullable: true, metadata: nil, data: [2.2]},
+               %Adbc.Column{name: "n3", type: :s64, nullable: true, metadata: nil, data: [1]},
+               %Adbc.Column{
+                 name: "n4",
+                 type: :string,
+                 nullable: true,
+                 metadata: nil,
+                 data: ["2021-01-01"]
+               },
+               %Adbc.Column{
+                 name: "n5",
+                 type: :string,
+                 nullable: true,
+                 metadata: nil,
+                 data: ["2021-01-01 00:00:00"]
+               }
+             ]
+           } = Adbc.Result.materialize(results)
 
     assert is_float(r1) and is_float(r3)
     assert abs(r1 - 1.1) < 1.0e-6
@@ -271,28 +354,54 @@ defmodule Adbc.SQLite.Test do
 
   test "bulk-queries", %{db: _, conn: conn} do
     assert {:ok,
-            %Adbc.Result{
-              data: [
-                %Adbc.Column{
-                  data: [1, 2],
-                  metadata: nil,
-                  name: "S64",
-                  nullable: true,
-                  type: :s64
-                },
-                %Adbc.Column{
-                  name: "F64",
-                  type: :f64,
-                  nullable: true,
-                  metadata: nil,
-                  data: [3.3, 4.4]
-                }
-              ],
+            results = %Adbc.Result{
+              data: %Adbc.Column{
+                data: _,
+                name: "",
+                type:
+                  {:struct,
+                   [
+                     %Adbc.Column{
+                       name: "S64",
+                       type: :s64,
+                       metadata: nil,
+                       nullable: true
+                     },
+                     %Adbc.Column{
+                       name: "F64",
+                       type: :f64,
+                       metadata: nil,
+                       nullable: true
+                     }
+                   ]},
+                metadata: nil,
+                nullable: true
+              },
               num_rows: nil
             }} =
              Connection.query(conn, "SELECT ? AS S64, ? AS F64", [
                Adbc.Column.s64([1, 2]),
                Adbc.Column.f64([3.3, 4.4])
              ])
+
+    assert %Adbc.Result{
+             data: [
+               %Adbc.Column{
+                 data: [1, 2],
+                 metadata: nil,
+                 name: "S64",
+                 nullable: true,
+                 type: :s64
+               },
+               %Adbc.Column{
+                 name: "F64",
+                 type: :f64,
+                 nullable: true,
+                 metadata: nil,
+                 data: [3.3, 4.4]
+               }
+             ],
+             num_rows: nil
+           } = Adbc.Result.materialize(results)
   end
 end

--- a/test/adbc_sqlite_test.exs
+++ b/test/adbc_sqlite_test.exs
@@ -76,7 +76,7 @@ defmodule Adbc.SQLite.Test do
       ]
     )
 
-    assert {:ok, results = %Adbc.Result{num_rows: nil, data: %{data: _, name: ""}}} =
+    assert {:ok, results = %Adbc.Result{num_rows: nil, data: _}} =
              Connection.query(conn, "SELECT * FROM test")
 
     assert list_result =
@@ -247,7 +247,7 @@ defmodule Adbc.SQLite.Test do
       ]
     )
 
-    assert {:ok, results = %Adbc.Result{num_rows: nil, data: %{data: _, name: ""}}} =
+    assert {:ok, results = %Adbc.Result{num_rows: nil, data: _}} =
              Connection.query(conn, "SELECT * FROM test")
 
     assert %Adbc.Result{
@@ -355,29 +355,20 @@ defmodule Adbc.SQLite.Test do
   test "bulk-queries", %{db: _, conn: conn} do
     assert {:ok,
             results = %Adbc.Result{
-              data: %Adbc.Column{
-                data: _,
-                name: "",
-                type:
-                  {:struct,
-                   [
-                     %Adbc.Column{
-                       name: "S64",
-                       type: :s64,
-                       metadata: nil,
-                       nullable: true
-                     },
-                     %Adbc.Column{
-                       name: "F64",
-                       type: :f64,
-                       metadata: nil,
-                       nullable: true
-                     }
-                   ]},
-                metadata: nil,
-                nullable: true
-              },
-              num_rows: nil
+              data: [
+                %Adbc.Column{
+                  name: "S64",
+                  type: :s64,
+                  metadata: nil,
+                  nullable: true
+                },
+                %Adbc.Column{
+                  name: "F64",
+                  type: :f64,
+                  metadata: nil,
+                  nullable: true
+                }
+              ]
             }} =
              Connection.query(conn, "SELECT ? AS S64, ? AS F64", [
                Adbc.Column.s64([1, 2]),

--- a/test/adbc_test.exs
+++ b/test/adbc_test.exs
@@ -146,22 +146,14 @@ defmodule AdbcTest do
 
       assert results =
                %Adbc.Result{
-                 data: %Adbc.Column{
-                   data: _,
-                   name: "",
-                   type:
-                     {:struct,
-                      [
-                        %Adbc.Column{
-                          name: "generate_series",
-                          type: {:timestamp, :microseconds, nil},
-                          metadata: nil,
-                          nullable: true
-                        }
-                      ]},
-                   metadata: nil,
-                   nullable: true
-                 }
+                 data: [
+                   %Adbc.Column{
+                     name: "generate_series",
+                     type: {:timestamp, :microseconds, nil},
+                     metadata: nil,
+                     nullable: true
+                   }
+                 ]
                } = Connection.query!(conn, query)
 
       assert %Adbc.Result{
@@ -296,63 +288,53 @@ defmodule AdbcTest do
       d6 = Decimal.new("-9876543210987654321098765432109876543.2")
       d7 = Decimal.new("1E-37")
 
-      assert {
-               :ok,
-               results = %Adbc.Result{
-                 data: %Adbc.Column{
-                   data: _,
-                   name: "duckdb_query_result",
-                   type:
-                     {:struct,
-                      [
-                        %Adbc.Column{
-                          name: "d1",
-                          type: {:decimal, 128, 38, 37},
-                          metadata: nil,
-                          nullable: true
-                        },
-                        %Adbc.Column{
-                          name: "d2",
-                          type: {:decimal, 128, 38, 37},
-                          metadata: nil,
-                          nullable: true
-                        },
-                        %Adbc.Column{
-                          name: "d3",
-                          type: :f64,
-                          metadata: nil,
-                          nullable: true
-                        },
-                        %Adbc.Column{
-                          name: "d4",
-                          type: :f64,
-                          metadata: nil,
-                          nullable: true
-                        },
-                        %Adbc.Column{
-                          name: "d5",
-                          type: {:decimal, 128, 38, 1},
-                          metadata: nil,
-                          nullable: true
-                        },
-                        %Adbc.Column{
-                          name: "d6",
-                          type: {:decimal, 128, 38, 1},
-                          metadata: nil,
-                          nullable: true
-                        },
-                        %Adbc.Column{
-                          name: "d7",
-                          type: {:decimal, 128, 38, 37},
-                          metadata: nil,
-                          nullable: true
-                        }
-                      ]},
-                   metadata: nil,
-                   nullable: false
-                 }
-               }
-             } =
+      assert {:ok,
+              results = %Adbc.Result{
+                data: [
+                  %Adbc.Column{
+                    name: "d1",
+                    type: {:decimal, 128, 38, 37},
+                    metadata: nil,
+                    nullable: true
+                  },
+                  %Adbc.Column{
+                    name: "d2",
+                    type: {:decimal, 128, 38, 37},
+                    metadata: nil,
+                    nullable: true
+                  },
+                  %Adbc.Column{
+                    name: "d3",
+                    type: :f64,
+                    metadata: nil,
+                    nullable: true
+                  },
+                  %Adbc.Column{
+                    name: "d4",
+                    type: :f64,
+                    metadata: nil,
+                    nullable: true
+                  },
+                  %Adbc.Column{
+                    name: "d5",
+                    type: {:decimal, 128, 38, 1},
+                    metadata: nil,
+                    nullable: true
+                  },
+                  %Adbc.Column{
+                    name: "d6",
+                    type: {:decimal, 128, 38, 1},
+                    metadata: nil,
+                    nullable: true
+                  },
+                  %Adbc.Column{
+                    name: "d7",
+                    type: {:decimal, 128, 38, 37},
+                    metadata: nil,
+                    nullable: true
+                  }
+                ]
+              }} =
                Connection.query(
                  conn,
                  """


### PR DESCRIPTION
This PR should allow us to use query results as inputs (query parameters) without allocating twice. 

~~However, by the design of ADBC, the value of `ArrowArray` and `ArrowSchema` will be moved once used as a parameter. And there is no deep copy function for `ArrowArray` comes with the nanoarrow  library.~~

~~It's possible to write one that does a deep copy of the `ArrowArray` but I'm not sure if that's what we wanted to do. But if so, I'll be happy to write one and send another PR for it.~~

Actually, a shallow copy + setting `release` to nullptr seems to be fine, and we can now reuse the results multiple times.