### PR TITLE
ci: precompile on ubuntu-20.04

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -10,13 +10,13 @@ permissions:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MIX_ENV: prod
     strategy:
       matrix:
         otp_version: [25]
-    
+
     name: Linux GNU - OTP ${{ matrix.otp_version }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.6.1
+
+#### Changes
+
+* Precompiling NIFs on `ubuntu-20.04` thus lowering the minimum required GLIBCXX version to `3.4.21`.
+
 ## v0.6.0
 
 #### Breaking changes

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Adbc.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
   @github_url "https://github.com/elixir-explorer/adbc"
 
   def project do


### PR DESCRIPTION
This is a quick fix that lowers the minimal required GLIBCXX version to `3.4.21`. It's possible that we can lower this requirement again if we precompile it in [`manylinux_2_28_x86_64`](https://quay.io/repository/pypa/manylinux_2_28_x86_64). I'll test this later!