### PR TITLE
fix: using `ArrowArrayInitFromType` when building list of strings

### DIFF
--- a/c_src/adbc_column.hpp
+++ b/c_src/adbc_column.hpp
@@ -423,7 +423,7 @@ int do_get_list_string(ErlNifEnv *env, ERL_NIF_TERM list, bool nullable, ArrowTy
 
     nanoarrow::UniqueArray tmp;
     struct ArrowArray* write_array = tmp.get();
-    NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromSchema(write_array, schema_out, error_out));
+    NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromType(write_array, nanoarrow_type));
     NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(write_array));
     int ret = get_list_string(env, list, nullable, write_array, ArrowArrayAppendString);
     if (ret == 0) {

--- a/test/adbc_test.exs
+++ b/test/adbc_test.exs
@@ -353,6 +353,36 @@ defmodule AdbcTest do
                      )
                    end
     end
+
+    test "list of strings", %{db: _, conn: conn} do
+      ids = ["1", "2", "3"]
+
+      assert {:ok, result} =
+               Adbc.Connection.query(
+                 conn,
+                 "SELECT $1",
+                 [Adbc.Column.list([Adbc.Column.string(ids)])]
+               )
+
+      assert %Adbc.Result{
+               data: [
+                 %Adbc.Column{
+                   data: [
+                     %Adbc.Column{
+                       data: ["1", "2", "3"],
+                       name: "item",
+                       type: :string,
+                       metadata: nil,
+                       nullable: true
+                     }
+                   ],
+                   type: :list,
+                   metadata: nil,
+                   nullable: true
+                 }
+               ]
+             } = result |> Adbc.Result.materialize()
+    end
   end
 
   describe "duckdb smoke tests" do


### PR DESCRIPTION
This PR should address the issue in #111 