### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,7 @@ MAKE_BUILD_FLAGS ?= -j$(DEFAULT_JOBS)
 
 .DEFAULT_GLOBAL := build
 
-all: adbc
-
-build: $(NIF_SO_REL)
+all: $(NIF_SO_REL)
 	@ if [ "${CI}" = "true" ]; then \
 		file "$(NIF_SO)" ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ MAKE_BUILD_FLAGS ?= -j$(DEFAULT_JOBS)
 
 .DEFAULT_GLOBAL := build
 
+all: adbc
+
 build: $(NIF_SO_REL)
 	@ if [ "${CI}" = "true" ]; then \
 		file "$(NIF_SO)" ; \


### PR DESCRIPTION
- catch-all on makefile for automated pipelines

This is particularly for Burrito which expects `elixir_make` files to have an `all` target. I don't necessarily see an issue adding an alias to the `adbc` target for `all` - but I'm also no C expert. Let me know if you think this would be an issue?