### PR TITLE
fix/windows: `bin` directory must exist before adding to dll search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.7.5
+
+#### Fixes
+
+* Creating `bin` directory if it does not exist on Windows before adding it to the DLL searching path (#123)
+
 ## v0.7.4
 
 #### Fixes

--- a/lib/adbc/dll_loader.ex
+++ b/lib/adbc/dll_loader.ex
@@ -4,7 +4,9 @@ defmodule Adbc.Nif.DLLLoader do
   def __on_load__ do
     case :os.type() do
       {:win32, _} ->
-        path = :filename.join(:code.priv_dir(:adbc), ~c"adbc_dll_loader")
+        priv_dir = :code.priv_dir(:adbc)
+        File.mkdir_p!(Path.join(priv_dir, "bin"))
+        path = :filename.join(priv_dir, ~c"adbc_dll_loader")
         :erlang.load_nif(path, 0)
         add_dll_directory()
 


### PR DESCRIPTION
Related issue: https://github.com/elixir-explorer/adbc/pull/120#issuecomment-2615488634

/cc @DnOberon 