### PR TITLE
fix/windows: the `dll` file was in `bin` instead of `lib`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Adbc.MixProject do
         make_precompiler_url:
           "#{@github_url}/releases/download/v#{@version}/@{artefact_filename}",
         make_precompiler_filename: "adbc_nif",
-        make_precompiler_priv_paths: ["adbc_nif.*", "adbc_dll_loader.dll", "lib", "include"],
+        make_precompiler_priv_paths: ["adbc_nif.*", "adbc_dll_loader.dll", "bin", "lib", "include"],
         make_precompiler_nif_versions: [versions: ["2.16"]],
         cc_precompiler: [
           cleanup: "clean",


### PR DESCRIPTION
So it turns out the shared library file `adbc_driver_manager.dll` is placed in `bin` instead of `lib` on Windows...very innovative...