### PR TITLE
chore(ci): build in container

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -15,7 +15,13 @@ permissions:
 jobs:
   linux:
     runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
+      ImageOS: ubuntu20
+      LANG: en_US.UTF-8
+      LANGUAGE: en_US:en
+      LC_ALL: en_US.UTF-8
+      DEBIAN_FRONTEND: noninteractive
       MIX_ENV: prod
 
     name: Linux GNU - OTP ${{ matrix.otp_version }}


### PR DESCRIPTION
Building in Ubuntu 24.04 generates NIF .so file that raises the minimum required GLIBCXX version to `3.4.29` (was requiring `3.4.21`).

```
==> adbc
Downloading precompiled NIF to /root/.cache/elixir_make/adbc-nif-2.16-x86_64-linux-gnu-0.7.9.tar.gz
Compiling 10 files (.ex)
Failed to load nif: {:load_failed, ~c"Failed to load NIF library: '/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /root/.cache/mix/installs/elixir-1.18.4-erts-15.2.7/351b1e6e3c80a83211c5014b3d2eb08c/_build/dev/lib/adbc/priv/adbc_nif.so)'"}
Generated adbc app
```

This PR builds the precompiled artifacts in ubuntu20.04 Docker container and addresses the above issue.