### PR TITLE
Support structs in Adbc.Column.to_list

### DIFF
--- a/lib/adbc_column.ex
+++ b/lib/adbc_column.ex
@@ -1386,11 +1386,19 @@ defmodule Adbc.Column do
 
   def to_list(%Adbc.Column{data: data, type: :list}), do: Enum.map(data, &to_list/1)
 
+  def to_list(%Adbc.Column{data: data, type: :struct}) do
+    struct_to_list(data)
+  end
+
   def to_list(%Adbc.Column{data: data, type: {:struct, _columns}}) do
+    struct_to_list(data)
+  end
+
+  def to_list(%Adbc.Column{data: data}), do: data
+
+  defp struct_to_list(data) do
     %Adbc.Result{data: data, num_rows: nil}
     |> Table.to_rows()
     |> Enum.to_list()
   end
-
-  def to_list(%Adbc.Column{data: data}), do: data
 end

--- a/test/adbc_column_test.exs
+++ b/test/adbc_column_test.exs
@@ -536,5 +536,108 @@ defmodule Adbc.Column.Test do
                %{"val1" => 162_342_654, "val2" => "hello elixir"}
              ]
     end
+
+    test "to list with list of structs" do
+      list_of_structs = %Adbc.Column{
+        name: "list_of_structs",
+        type: :list,
+        nullable: true,
+        metadata: nil,
+        data: [
+          %Adbc.Column{
+            name: "item",
+            type: :struct,
+            nullable: true,
+            metadata: nil,
+            data: [
+              %Adbc.Column{
+                name: "val1",
+                type: :string,
+                nullable: true,
+                metadata: nil,
+                data: ["hello1"],
+                length: nil,
+                offset: nil
+              },
+              %Adbc.Column{
+                name: "val2",
+                type: :string,
+                nullable: true,
+                metadata: nil,
+                data: ["world1"],
+                length: nil,
+                offset: nil
+              }
+            ],
+            length: nil,
+            offset: nil
+          },
+          %Adbc.Column{
+            name: "item",
+            type: :struct,
+            nullable: true,
+            metadata: nil,
+            data: [
+              %Adbc.Column{
+                name: "val1",
+                type: :string,
+                nullable: true,
+                metadata: nil,
+                data: ["hello2"],
+                length: nil,
+                offset: nil
+              },
+              %Adbc.Column{
+                name: "val2",
+                type: :string,
+                nullable: true,
+                metadata: nil,
+                data: ["world2"],
+                length: nil,
+                offset: nil
+              }
+            ],
+            length: nil,
+            offset: nil
+          },
+          %Adbc.Column{
+            name: "item",
+            type: :struct,
+            nullable: true,
+            metadata: nil,
+            data: [
+              %Adbc.Column{
+                name: "val1",
+                type: :string,
+                nullable: true,
+                metadata: nil,
+                data: ["hello3"],
+                length: nil,
+                offset: nil
+              },
+              %Adbc.Column{
+                name: "val2",
+                type: :string,
+                nullable: true,
+                metadata: nil,
+                data: ["world3"],
+                length: nil,
+                offset: nil
+              }
+            ],
+            length: nil,
+            offset: nil
+          }
+        ],
+        length: nil,
+        offset: nil
+      }
+
+      assert Adbc.Column.to_list(list_of_structs) == [
+               [%{"val1" => "hello1", "val2" => "world1"}],
+               [%{"val1" => "hello2", "val2" => "world2"}],
+               [%{"val1" => "hello3", "val2" => "world3"}]
+             ]
+    end
   end
 end


### PR DESCRIPTION
Adds support for `:struct` & `{:struct, columns}` types in `Adbc.Column.to_list`

Fixes an issue where reading data through `Table.to_rows()` would return `%Adbc.Column{}` values.