### PR TITLE
Add API to read Arrow data from Python back to Elixir

### DIFF
--- a/c_src/adbc_nif.cpp
+++ b/c_src/adbc_nif.cpp
@@ -476,6 +476,31 @@ static ERL_NIF_TERM adbc_arrow_array_stream_get_pointer(ErlNifEnv *env, int argc
     return enif_make_uint64(env, reinterpret_cast<uint64_t>(&res->val));
 }
 
+static ERL_NIF_TERM adbc_arrow_array_stream_from_pointer(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using res_type = NifRes<struct ArrowArrayStream>;
+    ERL_NIF_TERM error{};
+
+    ErlNifUInt64 pointer = 0;
+    if (!enif_get_uint64(env, argv[0], &pointer)) {
+        return enif_make_badarg(env);
+    }
+
+    auto array_stream = res_type::allocate_resource(env, error);
+    if (array_stream == nullptr) {
+        return error;
+    }
+
+    // We want to take full ownership of the stream, so we copy it
+    // into our resource-managed memory and we disable the release
+    // on the source, so that we are the ones responsible for
+    // releasing the stream.
+    auto source = reinterpret_cast<struct ArrowArrayStream *>(pointer);
+    memcpy(&array_stream->val, source, sizeof(struct ArrowArrayStream));
+    source->release = nullptr;
+
+    return erlang::nif::ok(env, array_stream->make_resource(env));
+}
+
 static ERL_NIF_TERM adbc_arrow_array_stream_next(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     using res_type = NifRes<struct ArrowArrayStream>;
     ERL_NIF_TERM error{};
@@ -1037,6 +1062,7 @@ static ErlNifFunc nif_functions[] = {
     {"adbc_statement_bind_stream", 2, adbc_statement_bind_stream, ERL_NIF_DIRTY_JOB_IO_BOUND},
 
     {"adbc_arrow_array_stream_get_pointer", 1, adbc_arrow_array_stream_get_pointer, 0},
+    {"adbc_arrow_array_stream_from_pointer", 1, adbc_arrow_array_stream_from_pointer, 0},
     {"adbc_arrow_array_stream_next", 1, adbc_arrow_array_stream_next, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"adbc_arrow_array_stream_release", 1, adbc_arrow_array_stream_release, ERL_NIF_DIRTY_JOB_IO_BOUND},
 

--- a/lib/adbc_nif.ex
+++ b/lib/adbc_nif.ex
@@ -64,6 +64,8 @@ defmodule Adbc.Nif do
 
   def adbc_arrow_array_stream_get_pointer(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
 
+  def adbc_arrow_array_stream_from_pointer(_pointer), do: :erlang.nif_error(:not_loaded)
+
   def adbc_arrow_array_stream_next(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)
 
   def adbc_arrow_array_stream_release(_arrow_array_stream), do: :erlang.nif_error(:not_loaded)

--- a/lib/adbc_result.ex
+++ b/lib/adbc_result.ex
@@ -61,6 +61,84 @@ defmodule Adbc.Result do
       {name, column |> Adbc.Column.materialize() |> Adbc.Column.to_list()}
     end)
   end
+
+  @doc """
+  Consumes Arrow data from a Python object that implements the
+  [ArrowStream Export interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrowstream-export).
+
+  The interface is typically implemented for dataframe objects, including
+  ones from Pandas and Polars.
+
+  It returns an ok-tuple with `Adbc.Result` or an error-tuple.
+  You often want to call `Adbc.Result.materialize/1` or
+  `Adbc.Result.to_map/1` on the results to consume it.
+  """
+  if Code.ensure_loaded?(Pythonx) do
+    def from_py(py_object) when is_struct(py_object, Pythonx.Object) do
+      {_, globals} =
+        Pythonx.eval(
+          """
+          if hasattr(object, "__arrow_c_stream__"):
+            import ctypes
+
+            has_stream = True
+            capsule = object.__arrow_c_stream__()
+            ctypes.pythonapi.PyCapsule_GetPointer.restype = ctypes.c_void_p
+            ctypes.pythonapi.PyCapsule_GetPointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
+            pointer = ctypes.pythonapi.PyCapsule_GetPointer(capsule, b"arrow_array_stream")
+
+          else:
+            has_stream = False
+            capsule = None
+            pointer = None
+          """,
+          %{"object" => py_object}
+        )
+
+      if Pythonx.decode(globals["has_stream"]) do
+        # We need to keep a reference to the stream, until we consume it.
+        capsule = globals["capsule"]
+        pointer = Pythonx.decode(globals["pointer"])
+
+        with {:ok, stream_ref} <- Adbc.Nif.adbc_arrow_array_stream_from_pointer(pointer) do
+          do_stream_results(stream_ref, [], capsule)
+        end
+      else
+        raise ArgumentError, """
+        the given Python object does not support ArrowStream Export interface (__arrow_c_stream__ method is missing)
+        """
+      end
+    end
+  else
+    def from_py(_py_object) do
+      raise """
+      Adbc.Result.from_py/4 requires pythonx to be available, add it to your mix.exs:
+
+          {:pythonx, "~> 0.4.0"}
+      """
+    end
+  end
+
+  defp do_stream_results(reference, acc, capsule) do
+    case Adbc.Nif.adbc_arrow_array_stream_next(reference) do
+      {:ok, result} ->
+        do_stream_results(reference, [result | acc], capsule)
+
+      :end_of_series ->
+        {:ok, %Adbc.Result{data: merge_columns(Enum.reverse(acc)), num_rows: nil}}
+
+      {:error, reason} ->
+        {:error, Adbc.Helper.error_to_exception(reason)}
+    end
+  end
+
+  defp merge_columns(chucked_results) do
+    Enum.zip_with(chucked_results, fn columns ->
+      Enum.reduce(columns, fn column, merged_column ->
+        %{merged_column | data: merged_column.data ++ column.data}
+      end)
+    end)
+  end
 end
 
 defimpl Table.Reader, for: Adbc.Result do

--- a/test/adbc_result_test.exs
+++ b/test/adbc_result_test.exs
@@ -94,4 +94,35 @@ defmodule Adbc.ResultTest do
              "time_series" => [[[1], [2, 3], [3, 4], [4]], [[3, 4], [4], [5, 6], [6]]]
            } == Result.to_map(result())
   end
+
+  describe "from_py" do
+    test "with invalid object" do
+      assert_raise ArgumentError, fn ->
+        {py_list, %{}} = Pythonx.eval("[]", %{})
+
+        Result.from_py(py_list)
+      end
+    end
+
+    test "with object implementing arrow stream" do
+      {py_table, %{}} =
+        Pythonx.eval(
+          """
+          import pyarrow
+          n_legs = pyarrow.array([2, 4, 5, 100])
+          animals = pyarrow.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+          names = ["n_legs", "animals"]
+          pyarrow.Table.from_arrays([n_legs, animals], names=names)
+          """,
+          %{}
+        )
+
+      {:ok, result} = Result.from_py(py_table)
+
+      assert %{
+               "n_legs" => [2, 4, 5, 100],
+               "animals" => ["Flamingo", "Horse", "Brittle stars", "Centipede"]
+             } == Result.to_map(result)
+    end
+  end
 end


### PR DESCRIPTION
Allows converting relevant `%Pythonx.Object{}` objects (for example a Pandas/Polars dataframe) into `Adbc.Result` (further consumable as plain Elixir data).