### PR TITLE
Include vendored `nanoarrow` source in Hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -111,7 +111,7 @@ defmodule Adbc.MixProject do
     [
       name: "adbc",
       files:
-        ~w(3rd_party/apache-arrow-adbc c_src lib mix.exs README* LICENSE* CMakeLists.txt Makefile Makefile.win checksum.exs),
+        ~w(3rd_party/apache-arrow-adbc 3rd_party/nanoarrow c_src lib mix.exs README* LICENSE* CMakeLists.txt Makefile Makefile.win checksum.exs),
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => @github_url}
     ]


### PR DESCRIPTION
Howdy, ADBC folks!

I have a bit of a special setup where I'm running on Alpine and need to build ADBC from source.  I just upgraded to 0.11.0 and my build threw an error because the `nanoarrow` source doesn't seem to be included in the Hex package like the source for `apache_arrow_adbc` is: https://github.com/livebook-dev/adbc/blob/main/mix.exs#L114

I'm working around the issue with a `git` checkout and copying the vendored source over to my `deps/adbc` dir during my image build, but figured I should propose this change here in case `nanoarrow` is around to stay.

Thanks for all the awesome work!